### PR TITLE
#334

### DIFF
--- a/StartupSession/Link/Expunge.aplf
+++ b/StartupSession/Link/Expunge.aplf
@@ -7,7 +7,10 @@
  :Trap DEBUG↓0
      :Hold '⎕SE.Link.Links'
          container←⊃⎕RSI ⎕XSI U.ContainerNs ⍬
-         :If ~U.HasLinks ⋄ r←container.⎕EX names ⋄ :Return ⋄ :EndIf
+         :If ~U.HasLinks 
+	 	r←container.⎕EX names 
+		:Return 
+ 	 :EndIf
          scal←1=≡,names ⋄ shape←⍴names←⊆names ⋄ r←(≢names←,names)⍴0
          :For i :In ⍳≢names
              nc←container U.NameClass name←(⍕container),'.',i⊃names


### PR DESCRIPTION
This solves the problem with fully qualified names  plus some cosmetic changes.

I wonder whether it is correct to address `⎕SE.Link.Links.ns` fully on line 22:

```
:AndIf (⊂U.NormNs name)∊⎕SE.Link.Links.ns  ⍝ is a link root
```

Why is `Links.ns` not good enough here?