### PR TITLE
Add preloaded switch to establish link w/o fixing

### DIFF
--- a/StartupSession/Dyalog/Array.apln
+++ b/StartupSession/Dyalog/Array.apln
@@ -200,14 +200,14 @@
               '('=⊃⍵:Paren{⍵,'⎕NS⍬'/⍨0=≢⍵}a Parse w ⍝ vector/empty ns
               ⍵ ⍝ dfn
           }
-           
+     
           SysVar←(L sysVars)∊⍨' '~¨⍨L∘⊆
-
+     
           ParseLine←{
               c←⍵⍳':'
               1≥≢(c↓⍵)~' ':'Missing value'⎕SIGNAL 6
               name←c↑⍵
-              (SysVar⍱¯1≠⎕NC) name:'Invalid name'⎕SIGNAL 2
+              (SysVar⍱¯1≠⎕NC)name:'Invalid name'⎕SIGNAL 2
               name(name,'←',⍺ Parse Over((c+1)↓⊢)⍵)
           }
      
@@ -237,9 +237,11 @@
               10::⍺ ExecuteEach ⍵ ⋄ ⍺⍎⍵       ⍝ attempt simple ⍎ and catch LIMIT ERROR
           }
      
-          w←↓⍣(2=≢⍴⍵)⊢⍵                  ⍝ mat?
-          w←{¯1↓∊⍵,¨⎕UCS 13}⍣(2=|≡w)⊢w   ⍝ vtv?
+          ⍝ Make normalised simple vector:
+          w←↓⍣(2=≢⍴⍵)⊢⍵                  ⍝ if mat, make nested
+          w←{¯1↓∊⍵,¨⎕UCS 13}⍣(2=|≡w)⊢w   ⍝ if nested, make simple
           w←'''[^'']*''' '⍝.*'⎕R'&' ''⊢w ⍝ strip comments
+          w/⍨←{(∨\⍵)∧⌽∨\⌽⍵}33≤⎕UCS w     ⍝ strip leading/trailing non-printables
      
           pl←ParenLev w
           (0≠⊢/pl)∨(∨/0>pl):'Unmatched brackets'⎕SIGNAL 2

--- a/StartupSession/Link/Create.aplf
+++ b/StartupSession/Link/Create.aplf
@@ -43,8 +43,10 @@
 
          :If emptydir⍱emptyns  ⍝ link issue #230
              opts.(ns dir)←(ns dir)
-         :AndIf 0∊⍴⎕SE.Link.U.Diff opts
-             emptydir←emptyns←1  ⍝ allow link creation
+             :If opts.preloaded
+             :OrIf 0∊⍴⎕SE.Link.U.Diff opts
+                 emptydir←emptyns←1  ⍝ allow link creation
+             :EndIf
          :EndIf
 
          :If ~Watcher.CanWatch ⋄ :AndIf (⊂opts.watch)∊'both' 'dir' ⋄ :AndIf ⎕SE.Link.Test≢⊃⎕RSI  ⍝ ⎕SE.Link.Test is allowed to toy with file watching/crawling
@@ -99,8 +101,10 @@
          :Case 'dir'
              :If 0≢opts.arrays ⋄ U.Warn'arrays modifier ignored when source≡''dir''' ⋄ :EndIf
              :If 0≢opts.sysVars ⋄ U.Warn'sysVars modifier ignored when source≡''dir''' ⋄ :EndIf
-             fail←2⊃opts U.FixFiles nsref dir 1 ⍝ we already checked the overwrite condition
-             :If ×≢fail ⋄ msg,←(⊂(⍕≢fail),' import(s) failed:'),U.WinSlash¨fail ⋄ :EndIf
+             :If 1≢opts.preloaded
+                 fail←2⊃opts U.FixFiles nsref dir 1 ⍝ we already checked the overwrite condition
+                 :If ×≢fail ⋄ msg,←(⊂(⍕≢fail),' import(s) failed:'),U.WinSlash¨fail ⋄ :EndIf
+             :EndIf
          :Else
              U.Error'Unknown source setting:'opts.source
          :EndSelect

--- a/StartupSession/Link/Create.aplf
+++ b/StartupSession/Link/Create.aplf
@@ -32,6 +32,7 @@
          :EndIf
 
          :If hasns←¯9.1=nc←U.NameClass ns
+         :AndIf ~opts.preloaded
              :If ~emptyns←0∊⍴U.ListNames nsref←⍎ns  ⍝ some APL names defined
              :AndIf ~emptydir                       ⍝ some dir/files defined
              :AndIf (⊂opts.source)∊'auto' 'dir'     ⍝ will not erase dir

--- a/StartupSession/Link/Notify.aplf
+++ b/StartupSession/Link/Notify.aplf
@@ -113,6 +113,7 @@
 
          :Case 'changed'               ⍝ Update to existing file?
              :If dir ⋄ :AndIf ¯9.1=# U.NameClass affected ⋄ →END⊣msg,←⊂'ignoring change to directory' ⋄ :EndIf
+             :If dir ⋄ :AndIf link.flatten ⋄ :AndIf 0=# U.NameClass affected ⋄ →END⊣msg,←⊂'ignoring change to directory' ⋄ :EndIf
              :If path≡curfile      ⍝ name already tied to the same file
                  msg,←'updating previously linked 'affected   ⍝ checking if file is worth refix-ing (hash etc.) will be done in U.QFix
                  :If (0<≢curname)∧(curname≢affected)   ⍝ name changed

--- a/StartupSession/Link/Utils.apln
+++ b/StartupSession/Link/Utils.apln
@@ -564,7 +564,7 @@
           :If ''≡0⍴opts ⋄ opts←⎕SE.Dyalog.Array.Deserialise opts ⍝ pseudo array notation (experimental)
           :Else ⋄ opts←⎕SE.Link.⎕NS opts  ⍝ duplicate namespace to avoid changing caller's, and to avoid having cross-refs between # and ⎕SE
           :EndIf
-          modifiers←'source' 'watch' 'flatten' 'caseCode' 'forceExtensions' 'forceFilenames' 'arrays' 'sysVars' 'fastLoad' 'beforeWrite' 'beforeRead' 'getFilename' 'customExtensions' 'codeExtensions' 'typeExtensions' 'proceed'
+          modifiers←'source' 'watch' 'flatten' 'caseCode' 'forceExtensions' 'forceFilenames' 'arrays' 'sysVars' 'fastLoad' 'beforeWrite' 'beforeRead' 'getFilename' 'customExtensions' 'codeExtensions' 'typeExtensions' 'proceed' 'preloaded'
           :If ~900⌶⍬ ⋄ modifiers,←defopts.⎕NL ¯2 ⋄ :EndIf
           :If ∨/mask←~(nl←opts.⎕NL ¯2)∊modifiers
               Error'Unknown modifiers: ',FmtEach mask/nl
@@ -576,8 +576,8 @@
           Check←Error{(⊂⍵⍵⍎⍺)∊⍵:_←1 ⋄ ⍺⍺'Invalid value ',(⍕⍵⍵⍎⍺),' for modifier "',⍺,'" - must be one of: ',⍕⍵}opts
           'source'Default'auto' ⋄ 'source'Check'auto' 'dir' 'ns'
           'watch'Default'both' ⋄ 'watch'Check'both' 'dir' 'ns' 'none'
-          'flatten' 'caseCode' 'forceExtensions' 'forceFilenames' 'fastLoad' 'sysVars'Default 0
-          'flatten' 'caseCode' 'forceExtensions' 'forceFilenames' 'fastLoad' 'sysVars'Check¨⊂0 1
+          'flatten' 'caseCode' 'forceExtensions' 'forceFilenames' 'fastLoad' 'sysVars' 'preloaded'Default 0
+          'flatten' 'caseCode' 'forceExtensions' 'forceFilenames' 'fastLoad' 'sysVars' 'preloaded'Check¨⊂0 1
           Check←Error{''≢0⍴v←⍵⍵⍎⍵:⍺⍺'Modifier "',⍵,'" must be a text vector' ⋄ (~0∊⍴v)∧(3≠⎕NC v):Error'Modifier ',⍵,' must be the name of an APL function' ⋄ 1:_←1}opts
           'beforeWrite' 'beforeRead' 'getFilename'Default'' ⋄ Check¨'beforeWrite' 'beforeRead' 'getFilename'
           Check←Error{∨/{''≢0⍴⍵}¨⊆⍵⍵⍎⍵:⍺⍺'Modifier "',⍵,'" must be a text vector or vector of text vectors' ⋄ 1:_←1}opts


### PR DESCRIPTION
This introduces a switch to bypass Link's initial checks and synchronization when establishing a link between a folder and a namespace that are already populated. It is left to the user to define a hooks to tell Link where an edited file is on disk etc.