### PR TITLE
Fix #395 v3.0.9: Break+)save creates ws with saved links

### DIFF
--- a/StartupSession/Link/Utils.apln
+++ b/StartupSession/Link/Utils.apln
@@ -514,12 +514,16 @@
         ∇ SetLinks links;fsw;mask
           :If 0∊⍴links ⋄ links←⍬ ⋄ :EndIf  ⍝ avoid putting empty vectors of references
           ⎕SE.Link.Links←links
-          :If HASSTORE ⋄ :AndIf ~0∊⍴links  ⍝ update # links in secret # area - they will be read by WSLoaded
-          :AndIf ~0∊⍴links←(#=RootOf⍎¨links.ns)/links
-              fsw←links.fsw  ⍝ nasty bug with ⎕NS and fsw which changes ⎕SE.Link.Links.fsw.##
-              links.fsw←⎕NULL  ⍝ nasty bug with ⎕NS and fsw which changes ⎕SE.Link.Links.fsw.##
-              {}(#.⎕NS¨links)Store 0   ⍝ avoid cross-ref between # and ⎕SE
-              links.fsw←fsw
+          :If HASSTORE ⍝ update # links in secret # area - they will be read by WSLoaded
+              :If ~0∊⍴links
+              :AndIf ~0∊⍴links←(#=RootOf⍎¨links.ns)/links
+                  fsw←links.fsw   
+                  links.fsw←⎕NULL 
+                  {}(#.⎕NS¨links)Store 0 ⍝ ⎕NS to avoid cross-ref between # and ⎕SE
+                  links.fsw←fsw
+              :Else
+                  {}⍬ Store 0 ⍝ Special-case empty list to avoid SYNTAX ERRORs etc in block above
+              :EndIf
           :EndIf
         ∇
         

--- a/StartupSession/Link/Version.aplf
+++ b/StartupSession/Link/Version.aplf
@@ -1,2 +1,2 @@
 version←Version
-version←'3.0.8'
+version←'3.0.9'


### PR DESCRIPTION
U.SetLinks was not updating the link store if there were no active links remaining.