### PR TITLE
Publish docs automatically with GitHub Actions

### DIFF
--- a/.github/workflows/mkdocs-mike-deploy.yml
+++ b/.github/workflows/mkdocs-mike-deploy.yml
@@ -1,0 +1,42 @@
+# Deploy mkdocs using mike for the version found using CI/inject_version.sh
+
+name: mkdocs-mike-deploy
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [master]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  docs_deploy:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    container: rikedyp/dtools
+    # runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Inject version and document revision information into docs/ source      
+      # Build and deploy docs site and pdf
+      - name: docs-deploy
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VER=$( CI/inject_version.sh )
+          MAJMIN=$(echo ${VER} | grep -o '[0-9]\+\.[0-9]\+')
+          git config user.name "GitHub Actions CI Publisher"
+          git config user.email "DyalogGithubActions@github.com"
+          git fetch origin gh-pages --depth=1
+          
+          mike deploy ${MAJMIN}
+          mike alias --update-aliases --push ${MAJMIN} latest
+ 

--- a/CI/inject_version.sh
+++ b/CI/inject_version.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Link inject_version.sh
+raw_version=`cat StartupSession/Link/Version.aplf | grep -o "^version\s\?←\s\?'[0-9]\+\.[0-9]\+\.0-\?\w\+\?" | grep -o "[0-9]\+\.[0-9]\+\.0-\?\w\+\?"`
+
+major_minor=`echo ${raw_version} | grep -o "[0-9]\+\.[0-9]\+"`
+special=`echo ${raw_version} | grep -o "\-\w\+$"`
+patch=`git rev-list --count HEAD`
+hash=`git rev-parse --short HEAD`
+date=`git show -s --format=%ci | cut -c -10`
+full_version=${major_minor}.${patch}${special}
+
+echo ${full_version}
+
+sed -i "s/^version\s\?←\s\?'[0-9]\+\.[0-9]\+\.0-\?\w\+\?/version←'${full_version}/" StartupSession/Link/Version.aplf
+
+exit 0

--- a/StartupSession/Link/Version.aplf
+++ b/StartupSession/Link/Version.aplf
@@ -1,2 +1,2 @@
 version←Version
-version←'3.0.8'
+version←'3.0.0'


### PR DESCRIPTION
This action reads the version number from `StartupSession/Link/Version.aplf` and publishes the built documentation to the gh-pages branch