### PR TITLE
Quote paths

### DIFF
--- a/StartupSession/Link/Create.aplf
+++ b/StartupSession/Link/Create.aplf
@@ -109,7 +109,7 @@
              :If 0≢opts.sysVars ⋄ U.Warn'sysVars modifier ignored when source≡''dir''' ⋄ :EndIf
              :If 1≢opts.preloaded
                  fail←2⊃opts U.FixFiles nsref dir 1 ⍝ we already checked the overwrite condition
-                 :If ×≢fail ⋄ msg,←(⊂(⍕≢fail),' import(s) failed:'),U.WinSlash¨fail ⋄ :EndIf
+                 :If ×≢fail ⋄ msg,←(⊂(⍕≢fail),' import(s) failed:'),U.FmtPath¨fail ⋄ :EndIf
              :EndIf
          :Else
              U.Error'Unknown source setting:'opts.source

--- a/StartupSession/Link/Export.aplf
+++ b/StartupSession/Link/Export.aplf
@@ -37,10 +37,10 @@
          (fixed failed)←opts U.WriteFiles src dest opts.overwrite
 
          :If ~single
-             msg←⊂'Exported: ',ns,' → ',U.WinSlash dir
+             msg←⊂'Exported: ',ns,' → ',U.FmtPath dir
              :If ×≢failed ⋄ msg,←(⊂'ERRORS ENCOUNTERED: ',(⍕≢failed),' export(s) failed:'),failed ⋄ :EndIf
          :ElseIf ×≢failed ⋄ msg←⊂'ERRORS ENCOUNTERED: Export failed: ',⊃failed
-         :Else ⋄ msg←⊂'Exported: ',src,' → ',U.WinSlash fixed
+         :Else ⋄ msg←⊂'Exported: ',src,' → ',U.FmtPath fixed
          :EndIf
          msg←1↓U.FmtLines msg
      :EndIf

--- a/StartupSession/Link/Import.aplf
+++ b/StartupSession/Link/Import.aplf
@@ -39,10 +39,10 @@
          (fixed failed)←opts U.FixFiles nsref src opts.overwrite
 
          :If ~single
-             msg←⊂'Imported: ',ns,' ← ',U.WinSlash dir
-             :If ×≢failed ⋄ msg,←(⊂'ERRORS ENCOUNTERED: ',(⍕≢failed),' import(s) failed:'),U.WinSlash¨failed ⋄ :EndIf
-         :ElseIf ×≢failed ⋄ msg←⊂'ERRORS ENCOUNTERED: Import failed: ',⊃U.WinSlash failed
-         :Else ⋄ msg←⊂'Imported: ',(⊃fixed),' ← ',U.WinSlash src
+             msg←⊂'Imported: ',ns,' ← ',U.FmtPath dir
+             :If ×≢failed ⋄ msg,←(⊂'ERRORS ENCOUNTERED: ',(⍕≢failed),' import(s) failed:'),U.FmtPath¨failed ⋄ :EndIf
+         :ElseIf ×≢failed ⋄ msg←⊂'ERRORS ENCOUNTERED: Import failed: ',⊃U.FmtPath failed
+         :Else ⋄ msg←⊂'Imported: ',(⊃fixed),' ← ',U.FmtPath src
          :EndIf
          msg←1↓U.FmtLines msg
      :EndIf

--- a/StartupSession/Link/Refresh.aplf
+++ b/StartupSession/Link/Refresh.aplf
@@ -19,12 +19,12 @@
                  :EndIf
                  0 Watcher.Pause link
                  :If 'ns'≡source
-                     ok,←⊂'Exported: ',ns,' → ',U.WinSlash link.dir
+                     ok,←⊂'Exported: ',ns,' → ',U.FmtPath link.dir
                      :If 0≠≢outFail←2⊃link U.WriteFiles link.ns link.dir 1 ⍝  always overwrite
                          ko,←(⊂(⍕≢outFail),' export(s) failed:'),outFail
                      :EndIf
                  :ElseIf 'dir'≡source
-                     ok,←⊂'Imported: ',ns,' ← ',U.WinSlash link.dir
+                     ok,←⊂'Imported: ',ns,' ← ',U.FmtPath link.dir
                      :If 0≠≢inFail←2⊃link U.FixFiles(⍎link.ns)link.dir 1  ⍝ always overwrite
                          ko,←(⊂(⍕≢inFail),' import(s) failed:'),inFail
                      :EndIf

--- a/StartupSession/Link/Test.dyalog
+++ b/StartupSession/Link/Test.dyalog
@@ -377,7 +377,7 @@
           'link issue #79'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
           'link issue #79'assert'foosrc≡⊃⎕NGET ''',folder,'/foo2.aplf'' 1'
           2 ref.⎕FIX foosrc2
-          assertError'⎕SE.Link.Export(name,''.foo'')(folder,''/foo2.aplf'')'(⎕SE.Link.U.WinSlash folder,'/foo2.aplf')
+          assertError'⎕SE.Link.Export(name,''.foo'')(folder,''/foo2.aplf'')'(⎕SE.Link.U.FmtPath folder,'/foo2.aplf')
           opts.overwrite←1
           z←opts ⎕SE.Link.Export(name,'.foo')(folder,'/foo2.aplf')
           'link issue #79'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
@@ -796,7 +796,7 @@
         ∇ ok←test_casecode(folder name);DummyFn;FixFn;actfiles;actnames;expfiles;expnames;files;fn;fn2;fnfile;fns;goo;mat;name;nl;nl3;ns;opts;sub;var;var2;varfile;winfolder;z
           
       ⍝ Test creating a folder from a namespace with Case Conflicts
-          winfolder←⎕SE.Link.U.WinSlash folder
+          winfolder←⎕SE.Link.U.FmtPath folder
           
           ns←⍎name ⎕NS''
           ns.('sub'⎕NS'')
@@ -1228,7 +1228,7 @@
           opts.typeExtensions←↑(2 'myapla')(3 'myaplf')(4 'myaplo')(9.1 'myapln')(9.4 'myaplc')(9.5 'myapli')
           (⊂newbody)⎕NPUT unlikelyfile 1  ⍝ make it invalid source
           z←opts ⎕SE.Link.Create name folder
-          assert'∧/∨/¨''ERRORS ENCOUNTERED'' (⎕SE.Link.U.WinSlash unlikelyfile)⍷¨⊂z'
+          assert'∧/∨/¨''ERRORS ENCOUNTERED'' (⎕SE.Link.U.FmtPath unlikelyfile)⍷¨⊂z'
           name⍎'var←1 2 3'
           {}⎕SE.Link.Add name,'.var'
           'link issue #104 and #97'assert'(,⊂''1 2 3'')≡⊃⎕NGET (folder,''/var.myapla'') 1'

--- a/StartupSession/Link/Utils.apln
+++ b/StartupSession/Link/Utils.apln
@@ -63,12 +63,13 @@
         NsExpr←{'''',⍵,'''⎕NS⍬'}                ⍝ Expression to create namespace
         Begins←{⊃⍺⍷⍵}                           ⍝ ⍵ starts with ⍺
         WinSlash←'\'@Slash⍣ISWIN                ⍝ force windows slashes only on windows machines
+        FmtPath←WinSlash 1∘⎕JSON                ⍝ Quote and escape quotes, then fix slashes
         DotSlash←'.'@Slash                      ⍝ Convert dots to slashes
         Combine←{(⍕⍺),⍨(326≠⎕DR ⍺)/'.',⍨⍕⍵}/
         List←{∊{' ',⍕⍵}¨⍵}
         Arrow←{                               ⍝ appropriate symbol to show ns-dir connection
             lr←'←→'/⍨2 2⊤'ns' 'dir' 'both'⍳⊂⍵.watch
-            ⍵.ns,' ',lr,' ',WinSlash ⍵.dir
+            ⍵.ns,' ',lr,' ',FmtPath ⍵.dir
         }
         HasNewlines←{∨/10 11 12 13 133 8232 8233∊⎕UCS ⍵}  ⍝ will confuse ⎕NGET/⎕NPUT and 2 ⎕FIX 'file://...'
         FmtEach←' '∘{∊⍺,∘⍕¨⍵}                    ⍝ error messages should not use (⍕'hello' 'world') because the UCMD framework detects the 2-spaces and wrap text "smartly"
@@ -976,7 +977,7 @@
       ⍝ Create directory for namespace
           3 ⎕MKDIR opts.dir ⋄ failed,←(~ok←⎕NEXISTS opts.dir)/⊂ns  ⍝ can't create directory
           :If (overwrite≡¯1)∧(ok) ⋄ :AndIf ~0∊⍴⊃opts(0 ListFiles 0)opts.dir  ⍝ exclude root dir
-              Error'Destination not empty: "',(WinSlash⍕dir),'"'
+              Error'Destination not empty: "',(FmtPath⍕dir),'"'
           :EndIf
       ⍝ Write files
           :If 0≠≢names←∪names
@@ -996,7 +997,7 @@
                   Error'File name case clash - try using caseCode←1:',FmtLines(ns,'.')∘,¨names[,(mask/inx),[1.5]⍸mask]
               :EndIf
               :If overwrite≡0 ⋄ :AndIf 1∊mask←⎕NEXISTS files
-                  Error'Files already exist: use the -overwrite flag to force overwriting the following files:',FmtLines WinSlash¨mask/files
+                  Error'Files already exist: use the -overwrite flag to force overwriting the following files:',FmtLines FmtPath¨mask/files
               :ElseIf overwrite≡1 ⋄ 3 ⎕NDELETE files
               :EndIf
               
@@ -1095,7 +1096,7 @@
               (allfiles parents expnames actnames actncs)/⍨←⊂~mask    ⍝ keep only names that are valid
               allnames←parents JoinNames actnames  ⍝ fully qualified names
               :If ∨/mask←(inx←⍳⍨allnames)≠(⍳≢allnames)
-                  Error'Files produce clashing APL names:',FmtLines↓⍕((WinSlash¨allfiles),(⊂'←→'),[1.5]allnames)[,(mask/inx),[1.5]⍸mask;]
+                  Error'Files produce clashing APL names:',FmtLines↓⍕((FmtPath¨allfiles),(⊂'←→'),[1.5]allnames)[,(mask/inx),[1.5]⍸mask;]
               :EndIf
           :EndIf
           


### PR DESCRIPTION
```
⎕SE.Link.Test.Run:  Running: test_basic  test_bugs  test_casecode  test_classic  test_create  test_diff  test_export  test_failures  test_flattened  test_forcefilenames  test_gui  test_import  test_threads  test_watcherror  
⎕SE.Link.Test.test_bugs:  "Expose Root Properties" not turned on - cannot QA issue #161 
⎕SE.Link.Test.test_classic:  Not a classic interpreter - not running test_classic 
⎕SE.Link.Test.test_gui:  Skipping  GUI (GhostRider) tests - set DO_GUI_TESTS←1 to enable 
Unlinked: #.linktest
⎕SE.Link.Test.Run:  14 test[s] passed OK in 57.2s with Link 3.0.16 on Dyalog 18.2 Unicode and .NetFramework 4.0 (USE_ISOLATES: 1) 
```