### PR TITLE
Docs ucmdhelp

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Link enables the use of text files as the primary storage mechanism for APL sour
 Two significantly different versions of Link are currently available:
 
 ## Version 3.0
-Version 3.0 is scheduled for distribution with the next release of Dyalog APL, and works with version 18.0. It is recommended to anyone getting started with Link and Dyalog APL. The [online documentation](https://dyalog.github.io/link/) is maintained using markdown files which can be found in `docs` folder and deployed using `mkdocs` and `mike`, hosted with GitHub Pages.
+Version 3.0 comes ready to use with installations of Dyalog APL version 18.2 and later. The [online documentation](https://dyalog.github.io/link/) is maintained using markdown files which can be found in `docs` folder and is deployed using `mkdocs` and `mike`, hosted with GitHub Pages.
 
-This version is actively developed in the master branch of this repository and supported via GitHub issues and via normal Dyalog support channels. Some early versions of this code still identify themselves as version 2.1, but there have been so many behavioural changes that that version number has been changed to 3.0.
+This version is actively developed in the master branch of this repository and supported via GitHub issues and via normal Dyalog support channels.
 
 ## Version 2.0
 Version 2.0 is distributed with Dyalog APL versions 17.1 and 18.0. It is no longer being actively developed. Support (and fixes if necessary) are available to Dyalog customers via our normal support channels.

--- a/docs/API/Link.Add.md
+++ b/docs/API/Link.Add.md
@@ -7,6 +7,8 @@
 message ← ⎕SE.Link.Add items
 ```
 
+!!! ucmdhelp "Show User Command information in the session with `]LINK.Add -?`"
+
 This function allows you to add one or more existing APL items to the link, creating the appropriate representation in the linked directory. Note that a source file will only be created or updated if the item is in a linked namespace.
 
 This is useful to write a new or modified array to a source file: [arrays are normally not written to file by Link](Link.Create.md#arrays).

--- a/docs/API/Link.Break.md
+++ b/docs/API/Link.Break.md
@@ -4,6 +4,8 @@
     
     message ← {options} ⎕SE.Link.Break namespace
 
+!!! ucmdhelp "Show User Command information in the session with `]LINK.Break -?`"
+
 Breaks an existing link: Does not affect the contents of the active workspace except to remove all traces of the link, preventing any further synchronisation from taking place.
 
 !!! Note

--- a/docs/API/Link.Create.md
+++ b/docs/API/Link.Create.md
@@ -5,6 +5,8 @@
     
     message ← {options} ⎕SE.Link.Create (namespace directory)
 
+!!! ucmdhelp "Show User Command information in the session with `]LINK.Create -?`"
+
 ## Arguments
 
 - `namespace` is either a reference to, or a simple character vector containing the name of a namespace.  

--- a/docs/API/Link.Export.md
+++ b/docs/API/Link.Export.md
@@ -4,6 +4,8 @@
     
     msg ← {opts} ⎕SE.Link.Export (ns dir) 
 
+!!! ucmdhelp "Show User Command information in the session with `]LINK.Export -?`"
+
 This function takes the same arguments as [Link.Create](Link.Create.md) but saves the contents of a namespace to directory without creating a Link.
 
 If the source is an unscripted namespace, then the destination is interpreted as a directory.

--- a/docs/API/Link.Expunge.md
+++ b/docs/API/Link.Expunge.md
@@ -4,6 +4,8 @@
     
     {available} ←  ⎕SE.Link.Expunge items
 
+!!! ucmdhelp "Show User Command information in the session with `]LINK.Expunge -?`"
+
 This function is intended as a replacement for the system
 function `⎕EX` in tools that manage code. It removes an item from the workspace and also deletes the corresponding source file.
 

--- a/docs/API/Link.Import.md
+++ b/docs/API/Link.Import.md
@@ -4,6 +4,8 @@
     
     msg ← {opts} ⎕SE.Link.Import (ns dir)
 
+!!! ucmdhelp "Show User Command information in the session with `]LINK.Import -?`"
+
 This function takes the same arguments as [Link.Create](Link.Create.md), but loads a directory containing source files into a namespace without creating an active link.
 
 If source is a directory, then its contents are imported into the destination namespace.

--- a/docs/API/Link.Refresh.md
+++ b/docs/API/Link.Refresh.md
@@ -4,6 +4,8 @@
     
     msg ← {opts} ⎕SE.Link.Refresh ns
 
+!!! ucmdhelp "Show User Command information in the session with `]LINK.Refresh -?`"
+
 Refresh will break and re-create a link by using one one side of the link as source, and bringing the other side into line.
 
 !!! Note

--- a/docs/API/Link.Resync.md
+++ b/docs/API/Link.Resync.md
@@ -4,6 +4,8 @@
     
     msg ← {opts} ⎕SE.Link.Resync ⍬
 
+!!! ucmdhelp "Show User Command information in the session with `]LINK.Resync -?`"
+
 `Link.Resync` will re-synchronise the contents of linked namespaces and the corresponding source directories. It is useful when:
 
 * You know that you have made changes of a type which will not trigger updates, such as function assignments or the `)COPY` system command

--- a/docs/API/Link.Status.md
+++ b/docs/API/Link.Status.md
@@ -4,6 +4,8 @@
     
     status ← {opts} ⎕SE.Link.Status ns 
 
+!!! ucmdhelp "Show User Command information in the session with `]LINK.Status -?`"
+
 This function provides information about existing links.
 
 #### Arguments

--- a/docs/API/index.md
+++ b/docs/API/index.md
@@ -14,7 +14,7 @@ where:
 - `FnName` is the name of the API function
 - `args` is either a character vector or a nested vector as described in the help section for that API function.
 
-## Option Namespaces
+### Option Namespaces
 Some API functions accept an option namespace as the left argument. For example, to create a link with non-default `source` and `flatten` options,
 you would write:
 
@@ -34,9 +34,12 @@ Most API functions have a corresponding user command, to make them a little easi
 ```apl
       ]LINK.Create myapp /sources/myapp -source=dir -flatten
 ```
+
 ***Lowercase option names:*** Although option names are case sensitive and some of them contain uppercase letters when provided to API functions via option namespaces, the user command option names are entirely lowercase, to make interactive use more convenient.
 
 ***Specifying extensions:*** Two options require arrays identifying file extensions: `codeExtensions`, `customExtensions` and `typeExtensions`. For convenience, the `]LINK.Create` user command accepts the *name* of a variable containing the array, rather than the array values. 
+
+A list of available user commands can be viewed in the session with `]LINK -?`. Help for a particular user command `Cmd` is displayed using `]LINK.Cmd -?`.
 
 ## Basic API Function reference
 

--- a/docs/style/admonition-ucmdhelp.css
+++ b/docs/style/admonition-ucmdhelp.css
@@ -1,0 +1,22 @@
+:root {
+	--md-admonition-icon--ucmdhelp: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 1.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13zM0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm9 3a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM6.92 6.085c.081-.16.19-.299.34-.398.145-.097.371-.187.74-.187.28 0 .553.087.738.225A.613.613 0 0 1 9 6.25c0 .177-.04.264-.077.318a.956.956 0 0 1-.277.245c-.076.051-.158.1-.258.161l-.007.004a7.728 7.728 0 0 0-.313.195 2.416 2.416 0 0 0-.692.661.75.75 0 0 0 1.248.832.956.956 0 0 1 .276-.245 6.3 6.3 0 0 1 .26-.16l.006-.004c.093-.057.204-.123.313-.195.222-.149.487-.355.692-.662.214-.32.329-.702.329-1.15 0-.76-.36-1.348-.863-1.725A2.76 2.76 0 0 0 8 4c-.631 0-1.155.16-1.572.438-.413.276-.68.638-.849.977a.75.75 0 1 0 1.342.67z"/></svg>')
+}
+.md-typeset .admonition.ucmdhelp,
+.md-typeset details.ucmdhelp {
+  border-color: rgb(43, 155, 70);
+}
+.md-typeset .ucmdhelp > .admonition-title,
+.md-typeset .ucmdhelp > summary {
+  background-color: rgba(43, 155, 70, 0.1);
+  border: rgb(43, 155, 70);
+}
+.md-typeset .ucmdhelp code {
+  font-family: APL;
+  font-size: 1.1em;
+}
+.md-typeset .ucmdhelp > .admonition-title::before,
+.md-typeset .ucmdhelp > summary::before {
+  background-color: rgb(43, 155, 70);
+  -webkit-mask-image: var(--md-admonition-icon--ucmdhelp);
+            mask-image: var(--md-admonition-icon--ucmdhelp);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ theme:
 
 extra_css:
   - style/main.css
+  - style/admonition-ucmdhelp.css
 
 plugins:
   - search


### PR DESCRIPTION
Adds admonitions (info boxes) to API pages with user commands for how to get help in the session:
![image](https://user-images.githubusercontent.com/9338369/188595741-f7f55aa1-8e43-4565-a229-de1b6d48eff4.png)
