### PR TITLE
Delete directories after export/create if they exist and are empty - addresses #497

### DIFF
--- a/StartupSession/Link/Create.aplf
+++ b/StartupSession/Link/Create.aplf
@@ -123,5 +123,9 @@
          ¯1 U.Log msg←1↓U.FmtLines(⊂'Linked: ',arrow,dircreated/⊂'[directory was created]'),((×≢msg)/⊂'ERRORS ENCOUNTERED:'),msg
      :EndHold
  :Else
+     :If dircreated
+     :AndIf 0∊⍴⊃0⎕NINFO⍠1⊢dir,'/*'
+        ⎕NDELETE dir
+     :EndIf
      U.Resignal 1
  :EndTrap

--- a/StartupSession/Link/Export.aplf
+++ b/StartupSession/Link/Export.aplf
@@ -45,5 +45,9 @@
          msg←1↓U.FmtLines msg
      :EndIf
  :Else
+     :If (~opts U.HasExtn dest) ∧ ⎕NEXISTS dest
+     :AndIf 0∊⍴⊃0⎕NINFO⍠1⊢dest,'/*'
+        ⎕NDELETE dest
+     :EndIf
      U.Resignal 1
  :EndTrap

--- a/StartupSession/Link/Test.dyalog
+++ b/StartupSession/Link/Test.dyalog
@@ -820,8 +820,8 @@
               ⎕NDELETE⍠1⊢folder
           :Else
               'Link issue #113'assert'∨/''File name case clash''⍷⊃⎕DM'
-          ⍝assert'~⎕NEXISTS folder'        ⍝ folder must not exist
-              assert'0∊⍴⊃⎕NINFO⍠1⊢folder,''/*'''  ⍝ folder must remain empty
+              assert'~⎕NEXISTS folder'        ⍝ folder must not exist
+              ⍝ assert'0∊⍴⊃⎕NINFO⍠1⊢folder,''/*'''  ⍝ folder must remain empty
           :EndTrap
           3 ⎕NDELETE folder
           :Trap ⎕SE.Link.U.ERRNO
@@ -830,8 +830,8 @@
               ⎕SE.Link.Break name
           :Else
               'Link issue #113'assert'∨/''File name case clash''⍷⊃⎕DM'
-          ⍝assert'~⎕NEXISTS folder'        ⍝ folder must not exist
-              assert'0∊⍴⊃⎕NINFO⍠1⊢folder,''/*'''  ⍝ folder must remain empty
+              assert'~⎕NEXISTS folder'        ⍝ folder must not exist
+              ⍝ assert'0∊⍴⊃⎕NINFO⍠1⊢folder,''/*'''  ⍝ folder must remain empty
           :EndTrap
           3 ⎕NDELETE folder
           


### PR DESCRIPTION
If someone creates an empty directory purposefully and the create/export fails, that directory will be wiped due to this change. That may be unwanted as it could be seen as annoying.