### PR TITLE
Qa refactoring

### DIFF
--- a/StartupSession/Link/Notify.aplf
+++ b/StartupSession/Link/Notify.aplf
@@ -14,7 +14,7 @@
 
      links←U.ErrorIfRestored U.GetLinks ⍝ never allow file notifications
 
-     hold←~(⊂⊃1↓⎕XSI)∊'⎕SE.Link.Notify' '⎕SE.Link.Watcher.Crawl'  ⍝ these already have the hold - avoid deadlock
+     hold←~(⊂⊃1↓⎕XSI)∊'⎕SE.Link.Notify' '⎕SE.Link.Watcher.Crawl' '⎕SE.LinkTest.Fix' ⍝ these already have the hold - avoid deadlock
      :Hold hold/'⎕SE.Link.Notify' '⎕SE.Link.Links'
      ⍝ :Hold '⎕SE.Link.Notify' is for functions that may modify files and file associations
      ⍝ :Hold '⎕SE.Link.Links' is just to get the link - we won't modify it - can't really hold it separately because Break/Expunge may have it too which could cause a deadlock

--- a/StartupSession/Link/Version.aplf
+++ b/StartupSession/Link/Version.aplf
@@ -1,2 +1,2 @@
 version←Version
-version←'4.0.4'
+version←'4.0.5'

--- a/Test/Breathe.aplf
+++ b/Test/Breathe.aplf
@@ -6,6 +6,8 @@
     ⍝ Also sometimes the FSW has create+change events on file write,
     ⍝ producing two callbacks to notify, the first one making assert succeeds,
     ⍝ then the second one conflicting with whichever code is run after the assert (e.g. a ⎕FIX which would be undone by the pending second Notify)
+ →USE_MOCK_FSW⍴0 ⍝ Not needed when we are mocking the FSW
+
  :If ⎕SE.Link.Watcher.DOTNET ⋄ ⎕DL 0.1  ⍝ FileSystemWatcher
  :Else ⋄ ⎕DL 2.1×⎕SE.Link.Watcher.INTERVAL ⍝ ensure two runs
  :EndIf

--- a/Test/CleanFolders.aplf
+++ b/Test/CleanFolders.aplf
@@ -1,0 +1,12 @@
+CleanFolders;names;z
+⍝ Utility to clear test folders after multiple failed/aborted tests
+
+:If 0=≢names←⊃1 ⎕NINFO⍠1⊢ (739⌶0),'/linktest-*'
+    ⎕←'Nothing to clean'
+    →0
+:EndIf
+
+⎕←⍪names
+z←⍞
+→(∨/'nN→'∊z)⍴0
+⎕NDELETE names

--- a/Test/InitGlobals.aplf
+++ b/Test/InitGlobals.aplf
@@ -1,16 +1,32 @@
  InitGlobals dummy
  ⎕IO←1 ⋄ ⎕ML←1
 
+ MODE←'MOCK'        ⍝ How to handle FSW events
+ ⍝ ''                 Just make changes, hope that FSW will kick in while tests run
+ ⍝                       Does not work at all.
+ ⍝ 'ISOLATE'          Redirect changes to an isolate and use Breathe+delays in "assert" to wait for FSW events to catch up
+ ⍝                       Works better, but is still subject to race conditions
+ ⍝ 'MOCK'             Turn off FSW, make updates via functions defined by SetupSlave, which call Notify directly
+ ⍝                       Seems to make
+ 'Invalid MODE' ⎕SIGNAL ((⊂MODE)∊'' 'MOCK' 'ISOLATE')↓11
+
+ USE_MOCK_FSW←MODE≡'MOCK'     ⍝ Mock the FSW
+ USE_ISOLATES←MODE≡'ISOLATE'  ⍝ Still supported in order to allow testing the FSW
+
+ MOCK_OFF←0         ⍝ Turn off mocking when pausing or not watching directory
+
+ NAME←'#.linktest'  ⍝ namespace created by link tests
+ TESTNS←⍕⎕THIS
  IGNORE_LINKS←'⎕SE.Link' '⎕SE.Dyalog' '⎕SE.LinkTest' ⍝ Pretend these don't exists while testing
  TESTS_LINKED←{6::0 ⋄ (⊂⍕⎕THIS)∊⎕SE.Link.Links.ns}⍬
 
  DO_GUI_TESTS←0     ⍝ Do not run GhostRider based tests by default
 
- NAME←'#.linktest'  ⍝ namespace used by link tests
- TESTNS←⍕⎕THIS
  APLVERSION←10÷⍨10⊥2↑2⊃'.' ⎕VFI 2⊃'.' ⎕WG 'APLVersion'
  FOLDER←''          ⍝ empty defaults to default to a new directory in (739⌶0)
 
- ASSERT_DORECOVER←0 ⍝ Attempt recovery if expression provided
+ ASSERT_DORECOVER←0 ⍝ Attempt recovery if expression provided in the argument to "assert"
+                    ⍝    This setting is a "bodge" to allow tests to continue after FSW-related failures
+
  ASSERT_ERROR←1     ⍝ Boolean : 1=assert failures will error and stop ⋄ 0=assert failures will output message to session and keep running
  STOP_TESTS←0       ⍝ Can be used in a failing thread to stop the action

--- a/Test/LinkCreate.aplf
+++ b/Test/LinkCreate.aplf
@@ -1,0 +1,18 @@
+{z}←{opts} LinkCreate args;i;ns
+:If 0=⎕NC 'opts' ⋄ opts←⎕NS ''
+:ElseIf (10|⎕DR opts)∊0 2 ⍝ Char?
+   opts←⎕SE.Dyalog.Array.Deserialise opts
+:EndIf
+
+z←opts ⎕SE.Link.Create args
+
+:If USE_MOCK_FSW ⍝ Disable the FSW
+   :If 9≠⎕NC 'ns'⊣ns←1⊃args
+       ns←⍎ns
+   :EndIf
+   i←⎕SE.Link.Links.ns⍳⊂⍕ns
+   :If ⎕SE.Link.Links[i].fsw≢⎕NULL
+      ⎕SE.Link.Links[i].fsw.Dispose
+      ⎕SE.Link.Links[i].fsw←⎕NULL
+   :EndIf
+:EndIf

--- a/Test/Notify.aplf
+++ b/Test/Notify.aplf
@@ -1,0 +1,6 @@
+{r}←Notify args
+:If USE_MOCK_FSW∧~MOCK_OFF
+    r←⎕SE.Link.Notify args
+:Else
+    r←⍬
+:EndIf

--- a/Test/Run.aplf
+++ b/Test/Run.aplf
@@ -28,8 +28,8 @@
  :EndIf
       ⍝ set up watcher/crawler
  (canwatch cancrawl interval)←⎕SE.Link.Watcher.(DOTNET CRAWLER INTERVAL)
- :If canwatch⍱cancrawl
-     Log'FileSystemWatcher or Crawler required to run tests'
+ :If ~USE_MOCK_FSW∨canwatch∨cancrawl
+     Log'Set USE_MOCK_FSW - no FileSystemWatcher or Crawler available'
      :Return
  :EndIf
       ⍝:If (canwatch⍲cancrawl)
@@ -60,14 +60,14 @@
      :If canwatch ⍝ test with file watcher
          ⎕SE.Link.Watcher.(CRAWLER DOTNET)←0 1
 ⍝_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓
-         ok∧←(⍎test)folder NAME      ⍝ ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ←         
+         ok∧←(⍎test)folder NAME      ⍝ ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ←
 ⍝¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑
      :EndIf
      :If cancrawl ⍝ test with crawler
      :AndIf ~(canwatch∧test≡'test_watcherrors')  ⍝ already done with file watcher - no need to do it with file crawler
          ⎕SE.Link.Watcher.(CRAWLER DOTNET)←1 0
 ⍝_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓_↓
-         ok∧←(⍎test)folder NAME      ⍝ ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ←         
+         ok∧←(⍎test)folder NAME      ⍝ ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ← ←
 ⍝¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑¯↑
      :EndIf
  :EndFor
@@ -83,6 +83,8 @@
  core←(1+⎕SE.Link.Watcher.DOTNETCORE)⊃'Framework' 'Core'
  aplv←{⍵↑⍨¯1+2⍳⍨+\'.'=⍵}2⊃'.'⎕WG'APLVersion'
  aplv,←' ',(1+82=⎕DR'')⊃'Unicode' 'Classic'
- opts←' (USE_ISOLATES: ',(⍕USE_ISOLATES),')'
+ opts←' (USE_ISOLATES: ',(⍕USE_ISOLATES),', '
+ opts,←'USE_MOCK_FSW: ',(⍕USE_MOCK_FSW),')'
+ 
  oktxt←(1+ok)⊃'!!! NOT OK !!!' 'OK'
  Log(⍕≢tests),' test[s] passed ',oktxt,' in',(1⍕time÷1000),'s with Link ',⎕SE.Link.Version,' on Dyalog ',aplv,' and .Net',core,' ',dnv,opts

--- a/Test/RunTestThread.aplf
+++ b/Test/RunTestThread.aplf
@@ -1,5 +1,5 @@
  loops RunTestThread(folder name);sub;z
- ⎕EX name ⋄ 3 ⎕NDELETE folder ⋄ 3 ⎕MKDIR folder
+ ⎕EX name ⋄ 3 ⎕NDELETE folder ⋄ 3 QMKDIR folder
  (⊂⎕SE.Dyalog.Array.Serialise 2 3 4⍴0)⎕NPUT folder,'/var.apla'
  (⊂'r←foo arg' 'r←''foo'' arg')⎕NPUT folder,'/foo.aplf'
  (⊂'r←(foo op) arg' 'r←''op'' foo arg')⎕NPUT folder,'/op.aplo'

--- a/Test/Setup.aplf
+++ b/Test/Setup.aplf
@@ -24,22 +24,7 @@
  :Else  ⍝ generate a new directory - avoids prompting for deletion
      folder←CreateTempDir 0
  :EndIf
- :If USE_ISOLATES
-     :If 9.1≠#.⎕NC⊂'isolate'
-         'isolate'#.⎕CY'isolate.dws'
-     :EndIf
-     {}#.isolate.Reset 0  ⍝ in case not closed properly last time
-     {}#.isolate.Config'processors' 1 ⍝ Only start 1 slave
-     #.SLAVE←#.isolate.New''
-     QNDELETE←{⍺←⊢ ⋄ ⍺ #.SLAVE.⎕NDELETE ⍵}
-     QNPUT←{⍺←⊢ ⋄ ⍺ #.SLAVE.⎕NPUT ⍵ ⋄ ⎕DL 0.001}  ⍝ ensure QNPUTS are not too tight for filewatcher
- :Else
-     #.SLAVE←⎕NS''
-     QNDELETE←{⍺←⊢ ⋄ ⍺ NDELETE ⍵}
-     QNPUT←{⍺ NPUT ⍵ ⋄ ⎕DL 0.001}
- :EndIf
-      ⍝QNMOVE←#.SLAVE.⎕NMOVE
-      ⍝QNCOPY←#.SLAVE.⎕NCOPY
-      ⍝QNGET←#.SLAVE.⎕NGET
-      ⍝QMKDIR←#.SLAVE.⎕MKDIR
+
+ SetupSlave ⍝ Set up "SLAVE" namespace for handling file operations
+
  r←folder

--- a/Test/SetupSlave.aplf
+++ b/Test/SetupSlave.aplf
@@ -1,0 +1,33 @@
+SetupSlave
+⍝ See InitGlobals for comments
+
+ :If USE_MOCK_FSW
+     ⍝ FSW switched off - mock the Notify calls that it WOULD have made
+     #.SLAVE←⎕NS''
+     QNDELETE←{⍺←⊢ ⋄ (Notify 'deleted' ⍵)⊢⍺ NDELETE ⍵ ⋄ }
+     QNPUT←{exists←⎕NEXISTS name←⊃⊆⍵ ⋄ (Notify ((⎕IO+exists)⊃'created' 'changed') name)⊢⍺ NPUT ⍵}
+     QNMOVE←{'*'∊⍵: ∘∘∘ ⋄ _←(Notify 'renamed' ⍺ ⍵)⊢⍺ ⎕NMOVE⍠('*'∊⍵)⊢⍵}
+     QMKDIR←{⍺←⊢ ⋄ _←(Notify 'created' ⍵)⊢⍺ ⎕MKDIR ⍵}
+
+ :ElseIf USE_ISOLATES
+     ⍝ Make file updates via isolate so FSW has a chance to work
+     :If 9.1≠#.⎕NC⊂'isolate'
+         'isolate'#.⎕CY'isolate.dws'
+     :EndIf
+     {}#.isolate.Reset 0  ⍝ in case not closed properly last time
+     {}#.isolate.Config'processors' 1 ⍝ Only start 1 slave
+     #.SLAVE←#.isolate.New''
+     QNDELETE←{⍺←⊢ ⋄ ⍺ #.SLAVE.⎕NDELETE ⍵}
+     QNPUT←{⍺←⊢ ⋄ _←⍺ #.SLAVE.⎕NPUT ⍵} ⍝ ensure QNPUTS are not too tight for filewatcher
+     QNMOVE←{_←⍺ #.SLAVE.{⍺ ⎕NMOVE⍠('*'∊⍵)⊢⍵} ⍵}
+     QMKDIR←{⍺←⊢ ⋄ _←⍺ #.SLAVE.⎕MKDIR ⍵}
+
+ :Else
+     ∘∘∘ ⍝ This just won't work, FSW events will not be processed in time
+     #.SLAVE←⎕NS''
+     QNDELETE←{⍺←⊢ ⋄ ⍺ NDELETE ⍵}
+     QNPUT←{_←⍺ NPUT ⍵}
+     QNMOVE←{_←⍺ ⎕NMOVE⍠('*'∊⍵)⊢⍵}
+     QMKDIR←{_←⍺←⊢ ⋄ ⍺ ⎕MKDIR ⍵}
+
+ :EndIf

--- a/Test/break_tests.aplf
+++ b/Test/break_tests.aplf
@@ -3,7 +3,7 @@
     ⍝ Called from test_basic
     ⍝ Assumes that both name and folder currently exist
 
- z←⎕SE.Link.Create name folder
+ z←LinkCreate name folder
  islinked←{2::0 ⋄ ∧/(⊆⍵)∊(⎕SE.Link.U.GetLinks).ns}
  'Create failed'assert'islinked name'
  z←⎕SE.Link.Break name                         ⍝ Test explicit break of a link
@@ -13,8 +13,8 @@
  folder2 ⎕NCOPY folder
  se_name←'⎕SE',1↓name
 
- z←⎕SE.Link.Create name folder
- z←⎕SE.Link.Create se_name folder2
+ z←LinkCreate name folder
+ z←LinkCreate se_name folder2
  'Create failed'assert'islinked name se_name'
 
 :If ~TESTS_LINKED
@@ -26,8 +26,8 @@
  'Break -all=* failed'assert'~islinked name'
 
  :For case :In '*'(,'*')                      ⍝ Test all alternatives of "all"
-     z←⎕SE.Link.Create name folder
-     z←⎕SE.Link.Create se_name folder2
+     z←LinkCreate name folder
+     z←LinkCreate se_name folder2
      'Create failed'assert'islinked name se_name'
      z←opts ⎕SE.Link.Break''⊣opts.all←case
      ('Break -all=',(⍕case),' failed')assert'0=≢⎕SE.Link.U.GetLinks'

--- a/Test/onBasicWrite.aplf
+++ b/Test/onBasicWrite.aplf
@@ -11,6 +11,6 @@
          src←value
          extn←⊂'.charvec'
      :EndSelect
-     {}(⊂src)QNPUT(∊(extn@3)⎕NPARTS file)1
+     {}(⊂src)⎕NPUT(∊(extn@3)⎕NPARTS file)1
      r←0 ⍝ We're done; Link doesn't need to do any more
  :EndIf

--- a/Test/test_basic.aplf
+++ b/Test/test_basic.aplf
@@ -1,5 +1,4 @@
  ok←test_basic(folder name);_;ac;bc;cb;cm;cv;file;foo;goo;goofile;link;m;new;nil;nl;ns;o2file;old;olddd;opts;otfile;start;t;tn;value;z;zoo;zzz;unlikelyname
-
  'link issue #265'assert'0=⎕NC''unlikelyname'''
  name ⎕NS ''
  (⍎name) ⎕SE.Link.Fix'res←unlikelyname' 'res←''unlikelyname'''  ⍝ replacement for 2 ⎕FIX in calling namespace
@@ -14,7 +13,7 @@
  opts.beforeWrite←TESTNS,'.onBasicWrite'
  opts.customExtensions←'charmat' 'charvec'
  opts.watch←'both'
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  assert'1=CountLinks'
  link←⊃⎕SE.Link.Links
  ns←#⍎name
@@ -41,22 +40,22 @@
  assert'ns.one2≡⎕SE.Dyalog.Array.Deserialise ⊃⎕NGET o2file 1'
 
       ⍝ Rename the array
- Breathe ⋄ Breathe ⋄ Breathe   ⍝ because the previous Fix can trigger several "changed" filewatcher callbacks, and the following ⎕NMOVE would confuse them
+ Breathe ⋄ Breathe ⋄ Breathe   ⍝ because the previous Fix can trigger several "changed" filewatcher callbacks, and the following QNMOVE would confuse them
  otfile←folder,'/onetwo.apla'
  z←ns.one2
- _←otfile #.SLAVE.⎕NMOVE o2file
+ _←otfile QNMOVE o2file
  assert'z≡ns.onetwo' 'ns.onetwo←z'
  assert'0=⎕NC ''ns.one2''' '⎕EX ''ns.one2'''
 
       ⍝ Create sub-folder
  Breathe
- _←#.SLAVE.⎕MKDIR folder,'/sub'
+ _←QMKDIR folder,'/sub'
  assert'9.1=ns.⎕NC ⊂''sub''' '''ns.sub'' ⎕NS '''''
 
       ⍝ Move array to sub-folder
  Breathe
  value←ns.onetwo
- _←(new←folder,'/sub/one2.apla')#.SLAVE.⎕NMOVE otfile
+ _←(new←folder,'/sub/one2.apla')QNMOVE otfile
  assert'value≡ns.sub.one2' 'ns.sub.one2←value'
  assert'0=⎕NC''ns.onetwo''' '⎕EX''ns.onetwo'''
 
@@ -96,7 +95,7 @@
  nl←'aClass' 'bClass' 'foo' 'onetwo'
  assert'nl≡ns.sub.⎕NL-⍳10'                             ⍝ contents are the same
  assert'0=ns.⎕NC''bus'''
- _←(folder,'/bus')#.SLAVE.⎕NMOVE folder,'/sub'
+ _←(folder,'/bus')QNMOVE folder,'/sub'
  assert'9.1=ns.⎕NC ⊂''bus''' '''ns.bus'' ⎕NS '''''     ⍝ bus is a namespace
  assert'3=ns.bus.⎕NC ''foo''' '2 ns.bus.⎕FIX ''file://'',folder,''/bus/foo.dyalog''' ⍝ bus.foo is a function
  assert'∨/''/bus/foo.dyalog''⍷4⊃ns.bus.(5179⌶)''foo''' ⍝ check connection is registered
@@ -108,13 +107,14 @@
  _←(folder,'/foo - copy.dyalog')#.SLAVE.⎕NCOPY folder,'/foo.dyalog' ⍝ simulate copy/paste
  Breathe ⋄ Breathe ⋄ Breathe ⍝ Allow FileSystemWatcher time to react (always needed)
  goofile←folder,'/goo.dyalog'
- _←goofile #.SLAVE.⎕NMOVE folder,'/foo - copy.dyalog' ⍝ followed by rename
+ _←goofile QNMOVE folder,'/foo - copy.dyalog' ⍝ followed by rename
  Breathe ⋄ Breathe ⋄ Breathe ⍝ Allow FileSystemWatcher some time to react (always needed)
       ⍝ Verify that the old function is still linked to the original file
  assert'old≡new←ns.(5179⌶)''foo''' '5178⌶''ns.foo'''
 
       ⍝ Now edit the new file so it defines 'zoo'
  tn←goofile ⎕NTIE 0 ⋄ 'z'⎕NREPLACE tn 5,⎕DR'' ⋄ ⎕NUNTIE tn ⍝ (beware UTF-8 encoded file)
+ Notify 'changed' goofile ⍝ No cover for QNREPLACE
       ⍝ Validate that this did cause zoo to arrive in the workspace
  zoo←' r←zoo x' ' x x'
  assert'zoo≡ns.⎕NR ''zoo''' 'ns.⎕FX zoo'
@@ -123,6 +123,7 @@
       ⍝ Finally edit the new file so it finally defines 'goo'
  tn←goofile ⎕NTIE 0
  'g'⎕NREPLACE tn 5,⎕DR'' ⍝ (beware UTF-8 encoded file)
+ Notify 'changed' goofile ⍝ No cover for ⎕NREPLACE
  ⎕NUNTIE tn
       ⍝ Validate that this did cause goo to arrive in the workspace
  goo←' r←goo x' ' x x'
@@ -180,7 +181,7 @@
  _←QNDELETE folder,'/foo.dyalog'
  assert'0=≢ns.⎕NL -⍳10' ⍝ top level namespace is now empty
 
- '()'⎕NPUT folder,'/array.apla'
+ _←(⊂'()') QNPUT folder,'/array.apla'
  'link issue #260'assert name,'≡',name,'.array.##'
 
  'link issue #263'assert'''No link to break in arguments''≡⎕SE.Link.Break ⍬'

--- a/Test/test_bugs.aplf
+++ b/Test/test_bugs.aplf
@@ -1,7 +1,7 @@
  ok←test_bugs(folder name);engine;foo;newbody;nr;opts;props;ref;root;search;server;src;src2;sub;todelete;unlikelyclass;unlikelyfile;unlikelyname;var;warn;z
     ⍝ Github issues
  name ⎕NS''
- ⎕MKDIR Retry⊢folder ⍝ folder must be non-existent
+ QMKDIR Retry⊢folder ⍝ folder must be non-existent
 
           ⍝ link issue #335
  z←name'abc'⎕SE.Link.Fix,⊂'[1 2 3]'
@@ -10,7 +10,7 @@
  ⎕EX name,'.abc'
 
       ⍝ link issue #112 : cannot break an empty link
- z←⎕SE.Link.Create name folder
+ z←LinkCreate name folder
  'link issue #112'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
  z←⎕SE.Link.Break name ⋄ ⎕EX name
  'link issue #112'assert'(∨/''Unlinked''⍷z)'
@@ -19,7 +19,7 @@
  root←⎕NS ⍬ ⋄ root NSMOVE #  ⍝ clear # - prevents using #.SLAVE
  '#.unlikelyname must be non-existent'assert'0∧.=⎕NC''#.unlikelyname'' ''⎕SE.unlikelyname'''
  {}(⊂unlikelyclass←,¨':Class unlikelyname' '∇ foo x' ' ⎕←x' '∇' '∇ goo ' '∇' ':Field var←123' ':EndClass')⎕NPUT unlikelyfile←folder,'/unlikelyname.dyalog'
- z←'{source:''dir''}'⎕SE.Link.Create # folder
+ z←'{source:''dir''}'LinkCreate # folder
  :If ~0.6∊1||#.⎕NC #.⎕NL-⍳10  ⍝ Options → Configure → Object Syntax → Expose Root Properties
      Log'"Expose Root Properties" not turned on - cannot QA issue #161'
  :EndIf
@@ -32,10 +32,10 @@
  ⎕EX'#.unlikelyname'
  # NSMOVE root ⋄ ⎕EX'root' ⍝ put back #
 
- z←⎕SE.Link.Create(name,'.⎕THIS')folder
+ z←LinkCreate(name,'.⎕THIS')folder
  'link issue #145'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
  'link issue #145'assert'1=CountLinks'
- z←⎕SE.Link.Create('⎕THIS.',name,'.sub')folder
+ z←LinkCreate('⎕THIS.',name,'.sub')folder
  'link issue #145'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
  'link issue #145'assert'2=CountLinks'
  :Trap ⎕SE.Link.U.ERRNO
@@ -53,11 +53,11 @@
  ⎕EX name
 
       ⍝ link issue #204
- z←⎕SE.Link.Create name folder
+ z←LinkCreate name folder
  'link issue #204'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
  'link issue #204'assert'1=CountLinks'
  ⎕EX name
- z←⎕SE.Link.Create'#.unlikelyname'folder
+ z←LinkCreate'#.unlikelyname'folder
  'link issue #204'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
  'link issue #204'assert'1=CountLinks'
  {}⎕SE.Link.Expunge'#.unlikelyname'
@@ -66,9 +66,9 @@
       ⍝ link issue #284 : ]link.break -all should close links under #
       ⍝ previously #111 stated it should close ALL links
  '⎕SE.unlikelyname must be non-existent'assert'0=⎕NC''⎕SE.unlikelyname'''
- z←⎕SE.Link.Create'⎕SE.unlikelyname'folder
- z←⎕SE.Link.Create'#.unlikelyname'folder
- z←⎕SE.Link.Create'#.unlikelyname.sub'folder
+ z←LinkCreate'⎕SE.unlikelyname'folder
+ z←LinkCreate'#.unlikelyname'folder
+ z←LinkCreate'#.unlikelyname.sub'folder
  assert'3=CountLinks'
  props←'Namespace' '' 'Directory' 'Files'
  z←{(~⍵[;1]∊IGNORE_LINKS)⌿⍵}⎕SE.Link.Status ''
@@ -86,9 +86,9 @@
  :EndIf
 
  ⎕EX'⎕SE.unlikelyname' '#.unlikelyname'
- z←⎕SE.Link.Create'⎕SE.unlikelyname'folder
- z←⎕SE.Link.Create'#.unlikelyname'folder
- z←⎕SE.Link.Create'#.unlikelyname.sub'folder
+ z←LinkCreate'⎕SE.unlikelyname'folder
+ z←LinkCreate'#.unlikelyname'folder
+ z←LinkCreate'#.unlikelyname.sub'folder
  assert'3=CountLinks'
  {}'{recursive:''on''}'⎕SE.Link.Break'#.unlikelyname'
  'link issue #111'assert'1=CountLinks'
@@ -99,9 +99,9 @@
 
       ⍝ link issue #117 : leave trailing slash in dir
       ⍝ superseeded by issue #146 when trailing slash was disabled altogether
- 'link issue #146'assertError'⎕SE.Link.Create name(folder,''/'')' 'Trailing slash reserved'
+ 'link issue #146'assertError'LinkCreate name(folder,''/'')' 'Trailing slash reserved'
  'link issue #146'assert'{6::1 ⋄ 0=CountLinks}⍬'
- z←⎕SE.Link.Create name folder
+ z←LinkCreate name folder
  'link issue #117'assert'1=CountLinks'
  'link issue #117'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
      ⍝ link issue #116 : ⎕SE.Link.Refresh should not error when given a dir
@@ -126,7 +126,7 @@
  opts.watch←'dir'
  opts.typeExtensions←↑(2 'myapla')(3 'myaplf')(4 'myaplo')(9.1 'myapln')(9.4 'myaplc')(9.5 'myapli')
  (⊂newbody)⎕NPUT unlikelyfile 1  ⍝ make it invalid source
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  assert'∧/∨/¨''ERRORS ENCOUNTERED'' (⎕SE.Link.U.WinSlash unlikelyfile)⍷¨⊂z'
  name⍎'var←1 2 3'
  z←⎕SE.Link.Add name,'.var'
@@ -139,7 +139,7 @@
  3 ⎕MKDIR folder
  (⊂';some text')⎕NPUT folder,'/config.ini'  ⍝ should be ignored
  (warn ⎕SE.Link.U.WARN)←(⎕SE.Link.U.WARN 1) ⋄ ⎕SE.Link.U.WARNLOG/⍨←0
- {}⎕SE.Link.Create name folder
+ {}LinkCreate name folder
  (⊂';some new text')⎕NPUT(folder,'/config.ini')1  ⍝ should be ignored
  Breathe ⍝ allow notify to run before the break
  {}⎕SE.Link.Expunge name ⋄ 3 ⎕NDELETE folder
@@ -180,20 +180,20 @@
 
       ⍝ .apln must clash with directory of the same name
  {}(⊂':Namespace sub' ':EndNamespace')QNPUT folder,'/sub.apln'
- assertError'z←⎕SE.Link.Create name folder' 'clashing APL names'
+ assertError'z←LinkCreate name folder' 'clashing APL names'
  ⎕NDELETE folder,'/sub.apln'
 
       ⍝ attempt to change a function to an operator
- {}⎕SE.Link.Create name folder
+ {}LinkCreate name folder
  name'foo'⎕SE.Link.Fix foo←' r←(op foo)arg' ' r←op arg' ⍝ turn foo into an operator
  Breathe
- {}(folder,'/foo.aplo')#.SLAVE.⎕NMOVE folder,'/foo.aplf'
+ {}(folder,'/foo.aplo')QNMOVE folder,'/foo.aplf'
  Breathe
  'link issue #142'assert'(props,[.5]name ''←→'' folder 7)≡⎕SE.Link.Status name'
 
       ⍝ attempt to create invalid directory
  (warn ⎕SE.Link.U.WARN)←(⎕SE.Link.U.WARN 1) ⋄ ⎕SE.Link.U.WARNLOG/⍨←0
- 3 ⎕MKDIR folder,'/New directory (1)/'
+ 3 QMKDIR folder,'/New directory (1)/'
  'link issue #183'assert'~0∊⍴''invalid name defined by file''⎕S ''\0''⊢⎕SE.Link.U.WARNLOG'
  ⎕SE.Link.U.WARN←warn
  3 ⎕NDELETE folder,'/New directory (1)/'
@@ -252,7 +252,7 @@
  opts←⎕NS ⍬
  opts.watch←'ns'
  {}(⊂todelete←':Namespace todelete' 'todelete←1' ':EndNamespace')QNPUT(folder,'/todelete.apln')1
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  'link issue #184'assert'0 0≡name⍎''⎕IO ⎕ML'''
 
  'link issue #140'assert'todelete≡⎕SRC ',name,'.todelete'
@@ -301,10 +301,10 @@
  # NSMOVE root ⋄ ⎕EX'root' ⍝ put back #
 
       ⍝ link issue #235
+ {}(⊂':Namespace ns' ':EndNamespace')QNPUT(folder,'/ns.apln')0
  (warn ⎕SE.Link.U.WARN)←(⎕SE.Link.U.WARN 1) ⋄ ⎕SE.Link.U.WARNLOG/⍨←0
  ⎕EX name
- {}(⊂':Namespace ns' ':EndNamespace')QNPUT(folder,'/ns.apln')0
- {}⎕SE.Link.Create name folder
+ {}LinkCreate name folder
  'link issue #235'assert'9.1=⎕NC⊂''',name,'.ns'''
  ⎕SE.Link.Expunge name,'.ns'
  Breathe
@@ -318,7 +318,7 @@
      {}(⊂engine←':Namespace  Engine' ' dup ← {⍵ ⍵}' ':EndNamespace')QNPUT(folder,'/Engine.apln')1
      {}(⊂master←':Require file://Slave.apln' ':Namespace  Master' ' dup ← ##.Slave.dup' ':EndNamespace')QNPUT(folder,'/Master.apln')1
      {}(⊂slave←':Namespace  Slave' ' dup ← {⍵ ⍵}' ':EndNamespace')QNPUT(folder,'/Slave.apln')1
-     z←⎕SE.Link.Create name folder
+     z←LinkCreate name folder
      'link issue #155'assert'1=CountLinks'
      'link issue #155'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
      'link issue #155'assert' ''Engine'' ''Master''  ''Server'' ''Slave'' ''UnlikelyName'' ≡ (⍎name).⎕NL -⍳10'
@@ -338,7 +338,7 @@
  3 ⎕NDELETE folder
  opts←⎕NS ⍬
  opts.arrays←,⊂'msg1,',name,'.msg2,⎕IO,',name,'.⎕ML'
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  'link issue #282'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
  'link issue #282'assert'1 1 0≡⎕NEXISTS ',⍕Stringify¨folder∘{⍺,'/msg',⍵,'.apla'}¨'123'
  'link issue #309'assert'1 1 0≡⎕NEXISTS ',⍕Stringify¨folder∘{⍺,'/',⍵,'.apla'}¨'⎕IO' '⎕ML' '⎕WX'
@@ -347,7 +347,7 @@
  opts.arrays←('wh!at')(name,'.!#')(name,'.''hello''')(name,'.dot')(name)
  3 ⎕NDELETE folder
  ⎕SE.Link.U.WARNLOG/⍨←0
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  'link issue #309'assert'1=≢⎕SE.Link.U.WARNLOG'
  search←(⊂'-arrays modifier: Non-array names ignored'),opts.arrays
  'link issue #309'assert'(⎕IO-⍨⍳≢search)≡{⍵[⍋⍵]}search ⎕S 3⊢ ⎕SE.Link.U.WARNLOG'

--- a/Test/test_casecode.aplf
+++ b/Test/test_casecode.aplf
@@ -28,7 +28,7 @@
  :EndTrap
  3 ⎕NDELETE folder
  :Trap ⎕SE.Link.U.ERRNO
-     z←opts ⎕SE.Link.Create name folder
+     z←opts LinkCreate name folder
      'Link issue #113'assert'0'
      ⎕SE.Link.Break name
  :Else
@@ -49,7 +49,7 @@
  3 ⎕NDELETE folder
 
       ⍝ try variables too
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  assert'z≡''Linked: ',name,' ←→ ',winfolder,' [directory was created] '''
  actfiles←{⍵[⍋⍵]}(1+≢folder)↓¨0 NTREE folder
  'link issue #43'assert'actfiles≡expfiles'
@@ -75,17 +75,17 @@
  assertError'opts ⎕SE.Link.Import name folder' 'clashing file names'
 
  opts.caseCode←1
- {}⎕SE.Link.Create name folder
+ {}LinkCreate name folder
  {}⎕SE.Link.Break name ⋄ ⎕EX name
 
       ⍝ survive clashing apl definitions despite different filenames
  {}(⊂'r←foo x' 'r←''foo'' x')∘QNPUT¨files←folder∘,¨'/clash1.aplf' '/clash2.aplf'
- assertError'opts ⎕SE.Link.Create name folder' 'clashing APL names'
+ assertError'opts LinkCreate name folder' 'clashing APL names'
  {}QNDELETE¨1↓files
 
       ⍝ forcefilename will rename file with proper casecoding
  assert'1 0≡⎕NEXISTS folder∘,¨''/clash1.aplf'' ''/foo-0.aplf'''
- {}opts ⎕SE.Link.Create name folder
+ {}opts LinkCreate name folder
  assert'0 1≡⎕NEXISTS folder∘,¨''/clash1.aplf'' ''/foo-0.aplf'''
 
       ⍝ check forcefilename on-the-fly
@@ -95,8 +95,8 @@
  assert'0 1≡⎕NEXISTS folder∘,¨''/NotDup.aplf'' ''/Dup-1.aplf'''
 
       ⍝ check file rename on-the-fly
- Breathe ⋄ Breathe ⋄ Breathe   ⍝ the previous operation requires extensive post-processing so that Notify handles the ⎕NMOVE triggered by the original Notify
- {}(folder,'/NotDup.aplf')#.SLAVE.⎕NMOVE(folder,'/Dup-1.aplf')
+ Breathe ⋄ Breathe ⋄ Breathe   ⍝ the previous operation requires extensive post-processing so that Notify handles the QNMOVE triggered by the original Notify
+ {}(folder,'/NotDup.aplf')QNMOVE(folder,'/Dup-1.aplf')
  assert'0 1≡⎕NEXISTS folder∘,¨''/NotDup.aplf'' ''/Dup-1.aplf'''
 
       ⍝ check apl rename on-the-fly
@@ -130,13 +130,13 @@
       ⍝ survive clashing apl definitions despite different filenames
  {}(⊂'r←goo x' 'r←''goo'' x')∘QNPUT¨files←folder∘,¨'/goo.apla' '/goo.apln'
  {}(⊂'r←hoo x' 'r←''hoo'' x')QNPUT folder,'/hoo.aplf'  ⍝ this one should remain as is
- assertError'{}opts ⎕SE.Link.Create name folder' 'clashing APL names'
+ assertError'{}opts LinkCreate name folder' 'clashing APL names'
  {}QNDELETE¨1↓files
 
       ⍝ check forceextensions - should not enforce casecoding
  assert'1 0 0≡⎕NEXISTS folder∘,¨''/goo.apla'' ''/goo.aplf'' ''/goo-0.aplf'''
  assert'1 0≡⎕NEXISTS folder∘,¨''/hoo.aplf'' ''/hoo-0.aplf'''
- {}opts ⎕SE.Link.Create name folder
+ {}opts LinkCreate name folder
  assert'0 1 0≡⎕NEXISTS folder∘,¨''/goo.apla'' ''/goo.aplf'' ''/goo-0.aplf'''
  assert'1 0≡⎕NEXISTS folder∘,¨''/hoo.aplf'' ''/hoo-0.aplf'''
 
@@ -149,8 +149,8 @@
  assert'0 1≡⎕NEXISTS folder∘,¨''/NotDupDup1.apla'' ''/NotDupDup1.aplf'''
 
       ⍝ check file rename on-the-fly
- Breathe ⋄ Breathe ⋄ Breathe   ⍝ the previous operation requires extensive post-processing so that Notify handles the ⎕NMOVE triggered by the original Notify
- {}(folder,'/NotDupDup1.apla')#.SLAVE.⎕NMOVE(folder,'/NotDupDup1.aplf')
+ Breathe ⋄ Breathe ⋄ Breathe   ⍝ the previous operation requires extensive post-processing so that Notify handles the QNMOVE triggered by the original Notify
+ {}(folder,'/NotDupDup1.apla')QNMOVE(folder,'/NotDupDup1.aplf')
  assert'0 1≡⎕NEXISTS folder∘,¨''/NotDupDup1.apla'' ''/NotDupDup1.aplf'''
  assert'fn≡⎕NR name,''.DupDup1'''
  assert'0=⎕NC name,''.NotDupDup1'''
@@ -256,7 +256,7 @@
  {}⎕SE.UCMD']Link.Expunge ',name
  'link issue #231'assert'0=⎕NC name'
  opts←⎕NS ⍬ ⋄ opts.(caseCode forceFilenames)←1
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  'link issue #231'assert'~''ERRORS ENCOUNTERED''⍷z'
  (name,'.Sub')⎕SE.Link.Fix'res←SubFoo arg' 'res←arg arg'
  'link issue #231'assert'(,⊂folder,''/Sub-1/SubFoo-11.aplf'')≡(0 NTREE folder)'

--- a/Test/test_classic.aplf
+++ b/Test/test_classic.aplf
@@ -3,7 +3,7 @@
      Log'Not a classic interpreter - not running ',⊃⎕SI
      ok←1 ⋄ :Return
  :EndIf
- 3 ⎕MKDIR folder
+ 3 QMKDIR folder
 
       ⍝ check that key and friends are correctly translated in classic edition
  {}⎕SE.Link.Create name folder
@@ -15,6 +15,7 @@
  goobytes←1+@8⊢foobytes  ⍝ turn foo into goo
  goosrc←{'g'@6⊢⍵}¨@1⊢foosrc
  goobytes{tie←⍵ ⎕NCREATE 0 ⋄ _←⍺ ⎕NAPPEND tie 83 ⋄ 1:_←⎕NUNTIE tie}folder,'/goo.aplf'
+ Notify 'changed' (folder,'/goo.aplf')
  assert'goosrc≡⎕NR ''',name,'.goo'''
 
  {}⎕SE.Link.Break name
@@ -24,7 +25,7 @@
  nsref←⍎name ⎕NS''⊣⎕EX name
  assert'nsref.⎕AVU[60]=8866'       ⍝ Default: right tack
  nsref.⎕FX foosrc←' foo' '⍝⊢'
- {}⎕SE.Link.Create name folder
+ {}LinkCreate name folder
  read←NREADALL folder,'/foo.aplf'
  assert'(3↑¯5↑read)≡¯30 ¯118 ¯94'  ⍝ UTF-8 U+22A2 right tack (ignore CRLF)
 
@@ -37,7 +38,7 @@
  {}⎕SE.Link.Break name
  ⎕EX name
 
- {}⎕SE.Link.Create name folder
+ {}LinkCreate name folder
  assert'foosrc≡⎕NR ''',name,'.foo'''
  assert'nsref.⎕AVU[60]=164'        ⍝ Check ⎕AVU has been set to non-default
  assert'⎕AVU[60]=8866'             ⍝ Check ⎕AVU has not been affected

--- a/Test/test_create.aplf
+++ b/Test/test_create.aplf
@@ -3,7 +3,7 @@
  subfolder←folder,'/sub' ⋄ subname←name,'.sub'
 
       ⍝ test default UCMD to ⎕THIS
- 2 ⎕MKDIR subfolder ⋄ name ⎕NS ⍬
+ 2 QMKDIR subfolder ⋄ name ⎕NS ⍬
       ⍝:With name ⋄ z←⎕SE.UCMD']Link.Create ',folder ⋄ :EndWith  ⍝ not goot - :With brings in locals into the target namespace
  z←(⍎name).{⎕SE.UCMD ⍵}']Link.Create ⎕THIS.⎕THIS ',folder
  assert'∨/''Linked:''⍷z'
@@ -25,7 +25,7 @@
  (⊂'foo' '2+2')⎕NPUT folder,'/foo~2.aplf' ⍝ one function in an "bad" place
  (⊂'goo' '2+2')⎕NPUT folder,'/goo.aplf'   ⍝ one function in a  "good" place
  (⊂'bar' '2+2')⎕NPUT folder,'/baz.aplf'   ⍝ one function in a  "wrong" place
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  'system variables not inherited'assert'0=subname⍎''⎕IO'''
  'expected functions not found'assert'3.1=',name,'.⎕NC ''foo'' ''goo'' ''bar'''
  z←(⍎name)⎕SE.Link.Fix'baz' '3+3'        ⍝ must NOT overwrite baz.aplf
@@ -40,21 +40,21 @@
       ⍝ test failing creations
  assert'{6::1 ⋄ 0=CountLinks}⍬'
  3 ⎕NDELETE folder ⋄ ⎕EX name ⋄ opts.source←'dir'
- assertError'opts ⎕SE.Link.Create name folder' 'Source directory not found'
+ assertError'opts LinkCreate name folder' 'Source directory not found'
  2 ⎕MKDIR subfolder ⋄ subname ⎕NS ⍬
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  'link issue #230'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
  {}⎕SE.Link.Break name
  subname⍎'foo←{⍺+⍵}'
- assertError'opts ⎕SE.Link.Create name folder' 'Destination namespace not empty'
+ assertError'opts LinkCreate name folder' 'Destination namespace not empty'
  3 ⎕NDELETE folder ⋄ ⎕EX name ⋄ opts.source←'ns'
- assertError'opts ⎕SE.Link.Create name folder' 'Source namespace not found'
+ assertError'opts LinkCreate name folder' 'Source namespace not found'
  2 ⎕MKDIR subfolder ⋄ subname ⎕NS ⍬
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  'link issue #230'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
  {}⎕SE.Link.Break name
- 3 ⎕MKDIR subfolder,'/subsub'
- assertError'opts ⎕SE.Link.Create name folder' 'Destination directory not empty'
+ 3 QMKDIR subfolder,'/subsub'
+ assertError'opts LinkCreate name folder' 'Destination directory not empty'
  ⎕EX name ⋄ 3 ⎕NDELETE folder
  assert'{6::1 ⋄ 0=CountLinks}⍬'
 
@@ -62,11 +62,11 @@
  ⍎name,'←⎕NS ⍬'  ⍝ unnamed namespace name
  2 ⎕MKDIR subfolder
  (⊂':Namespace ns' ':EndNamespace')⎕NPUT folder,'/ns.apln'
- 'link issue #197'assertError'opts ⎕SE.Link.Create name folder' 'Not a properly named namespace'
+ 'link issue #197'assertError'opts LinkCreate name folder' 'Not a properly named namespace'
  'link issue #197'assertError'⎕SE.Link.Import name folder' 'Not a properly named namespace'
  'link issue #197'assertError'⎕SE.Link.Import name (folder,''/ns.apln'')' 'Not a properly named namespace'
  ⎕EX name ⋄ ref←⎕NS ⍬  ⍝ unnamed namespace reference
- 'link issue #197'assertError'opts ⎕SE.Link.Create ref folder' 'Not a properly named namespace'
+ 'link issue #197'assertError'opts LinkCreate ref folder' 'Not a properly named namespace'
  'link issue #197'assertError'⎕SE.Link.Import ref folder' 'Not a properly named namespace'
  'link issue #197'assertError'⎕SE.Link.Import ref (folder,''/ns.apln'')' 'Not a properly named namespace'
  3 ⎕NDELETE folder
@@ -97,51 +97,51 @@
       ⍝ test source=auto
  opts.source←'auto'
       ⍝ both don't exist
- assertError'opts ⎕SE.Link.Create name folder' 'Cannot link a non-existent namespace to a non-existent directory'
+ assertError'opts LinkCreate name folder' 'Cannot link a non-existent namespace to a non-existent directory'
  assert'(~⎕NEXISTS folder)∧(0=⎕NC name)'
  assert'{6::1 ⋄ 0=CountLinks}⍬'
  {}⎕SE.Link.Break name ⋄ 3 ⎕NDELETE folder ⋄ ⎕EX name
       ⍝ only dir exists
  2 ⎕MKDIR folder
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  assert'(⎕NEXISTS folder)∧(9=⎕NC name)'
  sourceis←'((~⎕SE.Link.Links.ns∊IGNORE_LINKS)/⎕SE.Link.Links.source)≡'
  assert sourceis,',⊂''dir'''
  {}⎕SE.Link.Break name ⋄ 3 ⎕NDELETE folder ⋄ ⎕EX name
       ⍝ only ns exists
  name ⎕NS ⍬
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  assert'(⎕NEXISTS folder)∧(9=⎕NC name)'
  assert sourceis,',⊂''ns'''
  {}⎕SE.Link.Break name ⋄ 3 ⎕NDELETE folder ⋄ ⎕EX name
       ⍝ both exist
  2 ⎕MKDIR folder ⋄ name ⎕NS ⍬
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  assert'(⎕NEXISTS folder)∧(9=⎕NC name)'
  assert sourceis,',⊂''dir'''
  {}⎕SE.Link.Break name ⋄ 3 ⎕NDELETE folder ⋄ ⎕EX name
       ⍝ only dir is populated
  2 ⎕MKDIR subfolder ⋄ name ⎕NS ⍬
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  assert'(⎕NEXISTS folder)∧(9=⎕NC name)'
  assert sourceis,',⊂''dir'''
  {}⎕SE.Link.Break name ⋄ 3 ⎕NDELETE folder ⋄ ⎕EX name
       ⍝ only ns is populated
  2 ⎕MKDIR folder ⋄ subname ⎕NS ⍬
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  assert'(⎕NEXISTS folder)∧(9=⎕NC name)'
  assert sourceis,',⊂''ns'''
  {}⎕SE.Link.Break name ⋄ 3 ⎕NDELETE folder ⋄ ⎕EX name
       ⍝ both are populated
  2 ⎕MKDIR subfolder ⋄ subname ⎕NS ⍬
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  'link issue #230'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
  {}⎕SE.Link.Break name
  subname⍎'foo←{⍺+⍵}'
- assertError'opts ⎕SE.Link.Create name folder' 'Cannot link a non-empty namespace to a non-empty directory'
+ assertError'opts LinkCreate name folder' 'Cannot link a non-empty namespace to a non-empty directory'
  ⎕EX subname,'.foo'
  2 ⎕MKDIR subfolder,'/subsub'
- assertError'opts ⎕SE.Link.Create name folder' 'Cannot link a non-empty namespace to a non-empty directory'
+ assertError'opts LinkCreate name folder' 'Cannot link a non-empty namespace to a non-empty directory'
  3 ⎕NDELETE subfolder,'/subsub'
  assert'{6::1 ⋄ 0=CountLinks}⍬'
  3 ⎕NDELETE folder ⋄ ⎕EX name
@@ -192,7 +192,7 @@
 
  :If ⎕SE.Link.U.IS181 ⍝ link issue #144
      opts.source←'dir' ⋄ opts.watch←'both'
-     z←opts ⎕SE.Link.Create name folder
+     z←opts LinkCreate name folder
      'link issue #144'assert'badsrc1≡⎕SRC ',name,'.badns1'
      'link issue #144'assert'badsrc2≡⎕SRC ',name,'.badns2'
      {}⎕SE.Link.Break name ⋄ ⎕EX name
@@ -200,10 +200,10 @@
 
       ⍝ Link issue #173
  (⊂reqsrc)⎕NPUT reqfile 1 ⋄ opts.source←'dir'
- opts.watch←'dir' ⋄ 'link issue #173'assertError'opts ⎕SE.Link.Create name folder' ':Require' ⋄ ⎕EX name
- opts.watch←'ns' ⋄ 'link issue #173'assertError'opts ⎕SE.Link.Create name folder' ':Require' ⋄ ⎕EX name
- opts.watch←'none' ⋄ 'link issue #173'assertError'opts ⎕SE.Link.Create name folder' ':Require' ⋄ ⎕EX name
- opts.watch←'both' ⋄ z←opts ⎕SE.Link.Create name folder
+ opts.watch←'dir' ⋄ 'link issue #173'assertError'opts LinkCreate name folder' ':Require' ⋄ ⎕EX name
+ opts.watch←'ns' ⋄ 'link issue #173'assertError'opts LinkCreate name folder' ':Require' ⋄ ⎕EX name
+ opts.watch←'none' ⋄ 'link issue #173'assertError'opts LinkCreate name folder' ':Require' ⋄ ⎕EX name
+ opts.watch←'both' ⋄ z←opts LinkCreate name folder
  'link issue #206'assert'0 2 1≡name⍎''⎕IO ⎕ML ⎕WX'''
  :If 0 ⍝ :If ⎕SE.Link.U.IS181 ⋄ assert'~∨/''ERRORS ENCOUNTERED''⍷z'       ⍝ badns are reported as failed to fix since Link v2.1.0-beta42
  :Else ⋄ assert' ~∨/folder⍷ ''^Linked:.*$''  ''^.*badns.*$'' ⎕R '''' ⊢z '  ⍝ no failure apart from badns1 and badns2
@@ -227,7 +227,7 @@
  ⎕NDELETE⍠1⊢(folder,'/')∘,¨'AREQ*.apln' 'ZREQ*.apln'  ⍝ link issue #173
 
       ⍝ test source=dir watch=dir
- opts.source←'dir' ⋄ opts.watch←'dir' ⋄ z←opts ⎕SE.Link.Create name folder
+ opts.source←'dir' ⋄ opts.watch←'dir' ⋄ z←opts LinkCreate name folder
  assert'''Linked:''≡7↑z'
  assert'var∘≡¨⍎¨name subname,¨⊂''.var'''
  assert'∧/foosrc∘≡¨NR¨name subname,¨⊂''.foo'''  ⍝ source-as-typed
@@ -255,7 +255,9 @@
  {}(⊂varsrc)QNPUT(subfolder,'/var.apla')1
  0 assert_create 0
       ⍝ link issue #176 - test Pause - can't test Pause on watch='both' because the file would be tied with 2 ⎕FIX 'file://'
+
  {}⎕SE.Link.Pause name
+ MOCK_OFF←1
  {}(⊂newnssrc)QNPUT(subfolder,'/ns.apln')1    ⍝ write ns first because ⎕SRC is deceiptful
  {}(⊂newfoosrc)QNPUT(subfolder,'/foo.aplf')1
  {}(⊂newvarsrc)QNPUT(subfolder,'/var.apla')1
@@ -267,7 +269,7 @@
  assert'({6::1 ⋄ 0=CountLinks}⍬)∧(z≡1)'
 
       ⍝ now try source=dir watch=ns
- opts.source←'dir' ⋄ opts.watch←'ns' ⋄ {}opts ⎕SE.Link.Create name folder
+ opts.source←'dir' ⋄ opts.watch←'ns' ⋄ {}opts LinkCreate name folder
  1 assert_create 1 ⍝ NB dir contains "new" definitions
  'link issue #173'assert'0=+/~3⊃⎕SE.Link.U.GetFileTiesIn ',name
       ⍝ APL changes must be reflected to file
@@ -290,7 +292,8 @@
  {}⎕SE.Link.Expunge name
 
       ⍝ now try source=dir watch=none
- opts.source←'dir' ⋄ opts.watch←'none' ⋄ {}opts ⎕SE.Link.Create name folder
+ opts.source←'dir' ⋄ opts.watch←'none' ⋄ MOCK_OFF←1
+ {}opts LinkCreate name folder
  1 assert_create 1
  'link issue #173'assert'0=+/~3⊃⎕SE.Link.U.GetFileTiesIn ',name
  {}(⊂nssrc)QNPUT(subfolder,'/ns.apln')1    ⍝ write ns first because ⎕SRC is deceiptful
@@ -308,9 +311,9 @@
  {}⎕SE.Link.Break name
  3 ⎕NDELETE folder
 
-
       ⍝ now try source=ns watch=dir
- opts.source←'ns' ⋄ opts.watch←'dir' ⋄ opts.arrays←name,'.var,',name,'.sub.var'
+ opts.source←'ns' ⋄ opts.watch←'dir' ⋄ MOCK_OFF←0
+ opts.arrays←name,'.var,',name,'.sub.var'
  name⍎'derived←∧.∧'
  name⍎'array←1 2 3'
  :If ⎕SE.Link.Watcher.DOTNET ⍝ Test #397: Inject a .NET namespace
@@ -320,7 +323,7 @@
  #.outside.⎕FX'goo' '3+3'  ⍝ Create a namespace with a function in it
  name⍎'outside←#.outside'  ⍝ Embed a ref to it in our namespace
 
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  'link issue #397'assert'~⎕NEXISTS folder,''/System'''
  'link issue #442'assert'~⎕NEXISTS folder,''/outside'''
  'link issue #186'assert'∨/''',name,'.derived''⍷z'   ⍝ must warn about unsupported names
@@ -343,8 +346,8 @@
  ⎕EX'#.outside'
 
       ⍝ now try source=ns watch=ns
- opts.source←'ns' ⋄ opts.watch←'ns'
- {}opts ⎕SE.Link.Create name folder
+ opts.source←'ns' ⋄ opts.watch←'ns' ⋄ MOCK_OFF←1
+ {}opts LinkCreate name folder
  ⎕SE.UCMD'z←]Link.Add ',name,'.array ',name,'.var ',subname,'.var'  ⍝ can't add variable automatically when source=ns
  'link issue #194'assert'⊃''Added: ''⍷z'
  'link issue #194'assert'∧/⎕NEXISTS folder folder subfolder,¨''/array.apla'' ''/var.apla'' ''/var.apla'' '
@@ -363,7 +366,7 @@
 
       ⍝ now try source=ns watch=none
  opts.source←'ns' ⋄ opts.watch←'none'
- {}opts ⎕SE.Link.Create name folder
+ {}opts LinkCreate name folder
  {}⎕SE.Link.Add subname,'.var'  ⍝ can't add variable automatically when source=ns
  1 assert_create 1
  'link issue #173'assert'0=+/~3⊃⎕SE.Link.U.GetFileTiesIn ',name
@@ -385,7 +388,7 @@
  {}⎕SE.Link.Break name ⋄ 3 ⎕NDELETE folder
 
       ⍝ link issue #160 try having items in the namespace already tied to items in the folder
- ⎕EX name ⋄ subname ⎕NS'' ⋄ 3 ⎕MKDIR subfolder
+ ⎕EX name ⋄ subname ⎕NS'' ⋄ 3 QMKDIR subfolder
  {}(⊂nssrc)QNPUT(folder,'/ns.apln')1    ⍝ write ns first because ⎕SRC is deceiptful
  {}(⊂foosrc)QNPUT(folder,'/foo.aplf')1
  {}(⊂varsrc)QNPUT(folder,'/var.apla')1
@@ -394,9 +397,9 @@
  {}(⊂newvarsrc)QNPUT(subfolder,'/var.apla')1
  2(⍎name).⎕FIX'file://',folder,'/foo.aplf'
  2(⍎subname).⎕FIX'file://',subfolder,'/foo.aplf'
- opts.source←'auto' ⋄ opts.watch←'both'  ⍝ try source=auto
+ opts.source←'auto' ⋄ opts.watch←'both' ⋄ MOCK_OFF←1 ⍝ try source=auto
  assert'{6::1 ⋄ 0=CountLinks}⍬'
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  'link issue #160'assert'1=CountLinks'
  'link issue #160'assert sourceis,',⊂''dir'''
  1 assert_create 1
@@ -407,10 +410,10 @@
  2(⍎name).⎕FIX'file://',subfolder,'/foo.aplf'  ⍝ this time name from subfolder was linked into the root namespace
  opts.source←'dir' ⋄ opts.watch←'both'  ⍝ try source=dir
  assert'{6::1 ⋄ 0=CountLinks}⍬'
- 'link issue #160'assertError'opts ⎕SE.Link.Create name folder' 'Destination namespace not empty'
+ 'link issue #160'assertError'opts LinkCreate name folder' 'Destination namespace not empty'
  assert'{6::1 ⋄ 0=CountLinks}⍬'
  ⎕EX subname
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  'link issue #160'assert'1=CountLinks'
  1 assert_create 1
  'link issue #160'assert'({⍵[⍋⍵]}1 NSTREE name)≡{⍵[⍋⍵]} ',⍕Stringify¨(name,'.')∘,¨'foo' 'ns' 'sub' 'sub.foo' 'sub.ns' 'sub.var' 'var'
@@ -419,7 +422,7 @@
  2(⍎name).⎕FIX'file://',folder,'/foo.aplf'
  2(⍎subname).⎕FIX'file://',subfolder,'/foo.aplf'
  assert'{6::1 ⋄ 0=CountLinks}⍬'
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  'link issue #230'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
  'link issue #230'assert'1=CountLinks'
  {}⎕SE.Link.Break name
@@ -428,12 +431,12 @@
       ⍝    foosrc←⎕NR name,'.foo' ⋄ newfoosrc←⎕NR subname,'.foo'
       ⍝:EndIf
  3 ⎕NDELETE folder
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
  'link issue #160'assert'1=CountLinks'
  {}⎕SE.Link.Add name subname,¨⊂'.var'
  z←⎕SE.Link.Break name
  assert'{6::1 ⋄ 0=CountLinks}⍬'
- z←⎕SE.Link.Create name folder  ⍝ Link issue #230
+ z←LinkCreate name folder  ⍝ Link issue #230
 
  1 assert_create 1
  assert'({⍵[⍋⍵]}1 NSTREE name)≡{⍵[⍋⍵]} ',⍕Stringify¨(name,'.')∘,¨'foo' 'ns' 'sub' 'sub.foo' 'sub.ns' 'sub.var' 'var'
@@ -448,44 +451,45 @@
  files,←'var' 'sub/subvar'
  files←(folder,'/')∘,¨files,¨(⊂'.apla')
       ⍝(opts←⎕NS'').source←'ns'
-      ⍝z←opts ⎕SE.Link.Create name folder
+      ⍝z←opts LinkCreate name folder
  ⎕SE.UCMD'z←]link.create -source=ns ',name,' ',folder
  'link issue #187'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
  'link issue #187'assert'0∧.=⎕NEXISTS files'
  {}⎕SE.Link.Break name
  3 ⎕NDELETE folder
       ⍝opts.(arrays sysVars)←1
-      ⍝z←opts ⎕SE.Link.Create name folder
+      ⍝z←opts LinkCreate name folder
  ⎕SE.UCMD'z←]link.create -source=ns -arrays=1 -sysvars ',name,' ',folder  ⍝ link issue #194
  'link issue #187'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
  'link issue #187'assert'1∧.=⎕NEXISTS files'
  {}⎕SE.Link.Break name
  ⎕EX name ⋄ 3 ⎕NDELETE folder
+ MOCK_OFF←0
 
       ⍝ link issue #249
  ref←⍎(name,'.SubNs1')⎕NS ⍬
  ref.⎕FX'res←foo arg' 'res←arg'
  ref.⎕FIX':Namespace ns' ':EndNamespace'
  ref.var←○⍳3 4
- z←'{caseCode:1 ⋄ source:''ns'' ⋄ arrays:1 ⋄ sysVars:1}'⎕SE.Link.Create name folder
+ z←'{caseCode:1 ⋄ source:''ns'' ⋄ arrays:1 ⋄ sysVars:1}'LinkCreate name folder
  'link issue #249'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
  ⎕SE.Link.Expunge name
- z←'{caseCode:1 ⋄ source:''dir'' ⋄ fastLoad:1}'⎕SE.Link.Create name folder
+ z←'{caseCode:1 ⋄ source:''dir'' ⋄ fastLoad:1}'LinkCreate name folder
  'link issue #249'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
  ⎕SE.Link.Expunge name
- z←'{caseCode:1 ⋄ source:''dir'' ⋄ fastLoad:0}'⎕SE.Link.Create name folder
+ z←'{caseCode:1 ⋄ source:''dir'' ⋄ fastLoad:0}'LinkCreate name folder
  'link issue #249'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
  ⎕SE.Link.Expunge name
 
       ⍝ link issue #251
  {}(⊂'res←foo arg' 'res←arg arg')QNPUT folder,'/SubNs1-11/foo.dyalog'  ⍝ clashes with SubNs1.foo
  opts←⎕NS ⍬ ⋄ opts.caseCode←1 ⋄ opts.source←'dir' ⋄ opts.fastLoad←1
- 'link issue #251'assertError'opts ⎕SE.Link.Create name folder' 'clashing APL names'
+ 'link issue #251'assertError'opts LinkCreate name folder' 'clashing APL names'
  ⎕NDELETE folder,'/SubNs1-11/foo.dyalog'
  ⎕SE.Link.Expunge name
 
       ⍝ link issue #261
- {}⎕SE.Link.Create name folder
+ {}LinkCreate name folder
  'link issue #261'assertError'⎕SE.Link.Status 42' 'Not a linked namespace'
 
  CleanUp folder name

--- a/Test/test_diff.aplf
+++ b/Test/test_diff.aplf
@@ -1,6 +1,7 @@
  ok←test_diff(folder name);diff;exp;filemask;files;folders;garbfiles;namemask;names;namespaces;ns;opts;varfiles;vars;z;newvars;aplvars
  3 ⎕MKDIR folder
- {}'{watch:''none''}'⎕SE.Link.Create name folder
+ MOCK_OFF←1 ⍝ watch:none
+ {}'{watch:''none''}'LinkCreate name folder
  assert'0∊⍴⎕SE.Link.Diff name'
  3 ⎕MKDIR¨folders←folder∘,¨'' '/.hidden' '/sub'
  namespaces←name∘,¨'' '.sub'
@@ -19,7 +20,8 @@
  assert'({⍵[⍋⍵;]}{⍵[;2 3]}⎕SE.Link.Diff name)≡({⍵[⍋⍵;]}exp)'
  ⎕EX name
  assertError'⎕SE.Link.Diff name' 'Not linked:'
- {}'{watch:''none''}'⎕SE.Link.Create name folder
+
+ {}'{watch:''none''}'LinkCreate name folder
  assert'({⍵[⍋⍵;]}{⍵[;2 3]}⎕SE.Link.Diff name)≡({⍵[⍋⍵;]}exp)'
  3 ⎕NDELETE folder
  (aplvars←namespaces,¨⊂'.aplvar'){⍎⍺,'←⍵'}¨⊂(3 2 1)  ⍝ apl-only variables should be ignored
@@ -41,7 +43,7 @@
  3 ⎕MKDIR folders  ⍝ for hidden folder too
  {}(⊂⎕SE.Dyalog.Array.Serialise 4 5 6)∘{⍺ QNPUT ⍵ 1}¨folders,¨⊂'/var.apla'
  {}(⊂'res←foo arg' 'res←arg arg')∘{⍺ QNPUT ⍵ 1}¨folders,¨⊂'/foo.aplf'
- {}(⊂':Namespace ns ⋄ :EndNamespace')∘{⍺ QNPUT ⍵ 1}¨folders,¨⊂'/ns.apln'
+ {}(⊂,⊂':Namespace ns ⋄ :EndNamespace')∘{⍺ QNPUT ⍵ 1}¨folders,¨⊂'/ns.apln'
  {}(⊂'!TOTAL!GARBAGE!AGAIN!;;;')∘{⍺ QNPUT ⍵ 1}¨folders,¨⊂'/garbage.aplf'
  {}(⊂':Namespace garbage ⋄ :EndNamespace')∘{⍺ QNPUT ⍵ 1}¨folders,¨⊂'/garbage.ini'
  filemask←(~files∊folders,¨'/')∧(~files∊garbfiles)
@@ -52,9 +54,11 @@
  opts.arrays←aplvars
  assert'({⍵[⍋⍵;]}{⍵[;2 3]}opts ⎕SE.Link.Diff name)≡({⍵[⍋⍵;]}exp)'
  {}⎕SE.Link.Break name
-
  ⎕EX name
- (ns←⎕NS ⍬)NSMOVE #
+
+ MOCK_OFF←0 ⍝ Normal link coming up
+
+ (ns←⎕NS ⍬)NSMOVE # ⍝ Move everything out of # for a moment
  z←⎕SE.UCMD']link.create # ',folder
  diff←{⍵[;2 3]}#.{⎕SE.Link.Diff ⍵}⍬
  exp←(⊂''),[1.5]folder∘,¨'/garbage.aplf' '/sub/garbage.aplf'
@@ -62,7 +66,7 @@
  exp⍪←(2×~⎕SE.Link.U.IS181)↓'#.ns' '#.sub.ns' '' '',[1.5]'' '',folder∘,¨'/ns.apln' '/sub/ns.apln'
  assert'({⍵[⍋⍵;]}diff)≡({⍵[⍋⍵;]}exp)'
  {}⎕SE.Link.Break # ⋄ #.⎕EX #.⎕NL-⍳10
- # NSMOVE ns
+ # NSMOVE ns        ⍝ Restore #
 
  CleanUp folder name
  ok←1

--- a/Test/test_failures.aplf
+++ b/Test/test_failures.aplf
@@ -7,22 +7,22 @@
 
  opts←⎕NS''
  opts.source←'ns'
- assertError('opts ⎕SE.Link.Create''',name,'.ns_not_here'' ''',folder,'''')'Source namespace not found'
+ assertError('opts LinkCreate''',name,'.ns_not_here'' ''',folder,'''')'Source namespace not found'
 
  opts←⎕NS''
  opts.source←'dir'
- assertError('opts ⎕SE.Link.Create''',name,''' ''',folder,'/dir_not_here''')'Source directory not found'
+ assertError('opts LinkCreate''',name,''' ''',folder,'/dir_not_here''')'Source directory not found'
 
  name ⎕NS'' ⋄ 3 ⎕MKDIR folder
  opts←⎕NS'' ⋄ opts.source←'dir'
  name⍎'var←1 2 3'
- 'link issue #182'assertError('opts ⎕SE.Link.Create ',⍕Stringify¨name folder)('Destination namespace not empty: ',name)
+ 'link issue #182'assertError('opts LinkCreate ',⍕Stringify¨name folder)('Destination namespace not empty: ',name)
  ⎕EX name,'.var' ⋄ 3 ⎕NDELETE folder
 
  opts.source←'ns'
       ⍝ link issue #162 test unknown modifiers and invalid values - ⎕EN is almost impossible to predict : 911 when ⎕SE.Link.DEBUG←1, 701, 702 or 704 when ⎕SE.Link.DEBUG←0
  'link issue #162'assertError('⎕SE.UCMD '']link.create -BADMOD=BADVAL '',name,'' "'',folder,''"'' ')'unknown modifier' 0
- 'link issue #162'assertError'''{BADMOD:1 2 3}''⎕SE.Link.Create name folder' 'Unknown modifier'
+ 'link issue #162'assertError'''{BADMOD:1 2 3}''LinkCreate name folder' 'Unknown modifier'
  :For mod :In 'source' 'watch' 'flatten' 'caseCode' 'forceExtensions' 'forceFilenames' 'fastLoad' 'beforeWrite' 'beforeRead' 'getFilename'
      :Select mod
      :CaseList 'source' 'watch' ⋄ err←1 ⋄ erru←0 ⎕SE.Link.U.CaseText errf←'Invalid value'
@@ -35,7 +35,7 @@
          z←⎕SE.UCMD']link.create -',(0 ⎕SE.Link.U.CaseText mod),'=BADVAL ',name,' "',folder,'"'
          'link issue #162'assert'∨/erru⍷z'
      :EndIf
-     'link issue #162'assertError('''{',mod,':''''BADVAL''''}''⎕SE.Link.Create name folder')errf
+     'link issue #162'assertError('''{',mod,':''''BADVAL''''}''LinkCreate name folder')errf
  :EndFor
     ⍝ Mantis 18638 - handle lost source
     3 ⎕MKDIR folder
@@ -44,13 +44,13 @@
     2(⍎name).⎕FIX'file://',folder,'/lostclass.aplc'
     ⎕NDELETE folder,'/lostclass.aplc'
     (warn ⎕SE.Link.U.WARN)←(⎕SE.Link.U.WARN 1) ⋄ ⎕SE.Link.U.WARNLOG/⍨←0
-    z←opts ⎕SE.Link.Create name folder
+    z←opts LinkCreate name folder
     'Mantis 18638'assert'(∨/''ERRORS ENCOUNTERED''⍷z)∧(∨/''',name,'.lostclass''⍷z)'
     (⍎name).⎕EX'lostclass'
     'Mantis 18638'assert'~0∊⍴(''File not found: '',folder,''/lostclass.aplc'')⎕S ''\0''⊢⎕SE.Link.U.WARNLOG'
     ⎕SE.Link.U.WARN←warn
  :Else
-    z←opts ⎕SE.Link.Create name folder
+    z←opts LinkCreate name folder
  :EndIf
 
  assertError('name ''foo'' ⎕SE.Link.Fix '';;;'' '';;;'' ')('Invalid source')
@@ -72,13 +72,13 @@
 
  {}⎕SE.Link.Break name ⋄ ⎕EX name
 
- 3 ⎕MKDIR folder,'/sub/.git/info'
+ 3 QMKDIR folder,'/sub/.git/info'
  {}(⊂,⊂'goo←{''goo'' arg}')QNPUT(folder,'/sub/goo.aplf')1
  {}(⊂'hoo arg' '⎕←''hoo'' arg')QNPUT(folder,'/sub/.git/info/hoo.aplf')1
  {}(⊂'joo arg' '⎕←''joo'' arg')QNPUT(folder,'/.joo.aplf')1
  {}(⊂'koo arg' '⎕←''koo'' arg')QNPUT(folder,'/koo.tmp')1
  (warn ⎕SE.Link.U.WARN)←(⎕SE.Link.U.WARN 1) ⋄ ⎕SE.Link.U.WARNLOG/⍨←0
- z←⎕SE.Link.Create name folder
+ z←LinkCreate name folder
  assert'~∨/''ERRORS ENCOUNTERED''⍷z'
  names←'#.linktest.foo' '#.linktest.unlikelyname' '#.linktest.sub' '#.linktest.sub.goo'
  'link issue #156'assert'({⍵[⍋⍵]}names)≡({⍵[⍋⍵]}1 NSTREE name)'
@@ -107,12 +107,12 @@
  3 ⎕NDELETE folder
  name⍎'⎕USING←'''''
  :Trap 0 ⋄ {}name⍎'System.Environment' ⋄ :EndTrap  ⍝ external objects appear in name list only if accessed
- z←⎕SE.Link.Create name folder
+ z←LinkCreate name folder
  'link issue #220'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
  {}⎕SE.Link.Break name
 
  ⎕EX name
- 'link issue #226'assertError'⎕SE.Link.Create ''C:\temp\dir'' ''#.temp.dir'' ' 'Not a properly named namespace'
+ 'link issue #226'assertError'LinkCreate ''C:\temp\dir'' ''#.temp.dir'' ' 'Not a properly named namespace'
 
  CleanUp folder name
  ok←1

--- a/Test/test_flattened.aplf
+++ b/Test/test_flattened.aplf
@@ -2,9 +2,9 @@
      ⍝ Test the flattened scenario
  FLAT_TARGET←'app' ⍝ simulated user input to onFlatWrite: declare target folder for new function
 
- {}3 ⎕MKDIR Retry⊢folder
- {}3 ⎕MKDIR folder,'/app'
- {}3 ⎕MKDIR folder,'/utils'
+ {}3 QMKDIR Retry⊢folder
+ {}3 QMKDIR folder,'/app'
+ {}3 QMKDIR folder,'/utils'
 
       ⍝ ↓↓↓ Do not use QNPUT for these, they must NOT be asynchonous
  _←(⊂main←' r←main' 'r←dup 2')⎕NPUT folder,'/app/main.aplf'        ⍝ One "application" function
@@ -13,7 +13,7 @@
  opts←⎕NS''
  opts.(flatten source)←1 'dir'
  opts.getFilename←TESTNS,'.onFlatFilename'
- z←opts ⎕SE.Link.Create name folder
+ z←opts LinkCreate name folder
 
  ns←#⍎name
 

--- a/Test/test_forcefilenames.aplf
+++ b/Test/test_forcefilenames.aplf
@@ -2,7 +2,7 @@
          ⍝ Test that forceFilenames is handled
 
  name ⎕NS''
- z←'{forceFilenames:1}'⎕SE.Link.Create name folder
+ z←'{forceFilenames:1}'LinkCreate name folder
  ns←#⍎name
 
       ⍝ Create a monadic function

--- a/Test/test_gui.aplf
+++ b/Test/test_gui.aplf
@@ -36,7 +36,7 @@
  {}(⊂varsrc)QNPUT(folder,'/sub/var.apla')1
  {}(⊂foo)QNPUT(folder,'/sub/foo.aplf')1
  {}(⊂class)QNPUT(folder,'/sub/class.aplc')1
- output←ride.APL' ''{flatten:1}'' ⎕SE.Link.Create ',(Stringify name),' ',(Stringify folder)
+ output←ride.APL' ''{flatten:1}'' LinkCreate ',(Stringify name),' ',(Stringify folder)
  assert'(∨/''Linked:''⍷output)'
 
       ⍝ https://github.com/Dyalog/link/issues/48
@@ -64,7 +64,7 @@
  {}(⊂varsrc)QNPUT(folder,'/var.apla')1
  {}(⊂foo)QNPUT(folder,'/foo.aplf')1
  {}(⊂class)QNPUT(folder,'/class.aplc')1
- output←ride.APL'  ⎕SE.Link.Create ',(Stringify name),' ',(Stringify folder)
+ output←ride.APL'  LinkCreate ',(Stringify name),' ',(Stringify folder)
  assert'(⊃''Linked:''⍷output)'
 
      ⍝ link issue #190: edit a non-existing name, and change its name before fixing

--- a/Test/test_watcherror.aplf
+++ b/Test/test_watcherror.aplf
@@ -4,12 +4,12 @@
      ok←1
      :Return
  :EndIf
- 3 ⎕MKDIR src←folder,'/src'
+ 3 QMKDIR src←folder,'/src'
  {(⊂'foo',⍵)⎕NPUT(src,'/foo',⍵,'.aplf')1}¨⍕¨⍳n←10000
- 3 ⎕MKDIR link←folder,'/link'
+ 3 QMKDIR link←folder,'/link'
  (warn ⎕SE.Link.U.WARN)←(⎕SE.Link.U.WARN 1) ⋄ ⎕SE.Link.U.WARNLOG/⍨←0
- {}⎕SE.Link.Create name link
- link ⎕NMOVE⍠1⊢src,'/foo*.aplf'
+ {}LinkCreate name link
+ link QNMOVE⍠1⊢src,'/foo*.aplf'
  :If ⎕SE.Link.Watcher.DOTNET>⎕SE.Link.Watcher.DOTNETCORE ⍝ DOTNETCORE does not support FileSystemWatcher errors yet ?
      'link issue #120'assert'~0∊⍴''FileSystemWatcher error on linked directory''⎕S ''\0''⊢⎕SE.Link.U.WARNLOG'
  :EndIf

--- a/Test/try_crawler.aplf
+++ b/Test/try_crawler.aplf
@@ -5,9 +5,9 @@
  assert'0∊⍴⎕SE.Link.U.GetLinks'
  (crawler dotnet)←⎕SE.Link.Watcher.(CRAWLER DOTNET)
  ⎕SE.Link.Watcher.(CRAWLER DOTNET)←1 0
- ⎕EX name ⋄ 3 ⎕NDELETE folder ⋄ 3 ⎕MKDIR folder
+ ⎕EX name ⋄ 3 ⎕NDELETE folder ⋄ 3 QMKDIR folder
  opts←⎕NS ⍬ ⋄ opts.watch←'none'  ⍝ not only to disable watcher, but also to prevent tying source to files
- {}opts ⎕SE.Link.Create name folder
+ {}opts LinkCreate name folder
  assert'1=CountLinks'
  link←⊃⎕SE.Link.Links
  ⎕SE.Link.Watcher.AddCrawler link  ⍝ because we have set watch←'none'
@@ -20,7 +20,7 @@
  }
  assert'0∧.=≢¨( 1 NSTREE name)(1 NTREE folder)'
       ⍝ create files
- 3 ⎕MKDIR¨(folder,'/')∘,¨'sub1' 'sub1/subsub1'
+ 3 QMKDIR¨(folder,'/')∘,¨'sub1' 'sub1/subsub1'
  (⊂matsrc←⎕SE.Dyalog.Array.Serialise mat←⍳3 4)⎕NPUT folder,'/sub1/mat.apla'
  (⊂tradfn←'   res ← tradfn (arg1 arg2)   ' '   res ← arg1 arg2   ')⎕NPUT folder,'/sub1/tradfn.aplf'
  (⊂dop←,⊂'dop←{⍺ ⍺⍺ ⍵⍵ ⍵}')⎕NPUT folder,'/sub1/dop.aplo'
@@ -61,7 +61,7 @@
       ⍝ check it worked
  assert'0 2≡≢¨( 1 NSTREE name)(1 NTREE folder)'
       ⍝ create items on both sides
- 3 ⎕MKDIR¨folders←(folder,'/')∘,¨'sub1' 'sub3' 'sub1/subsub1' 'sub3/subsub3'
+ 3 QMKDIR¨folders←(folder,'/')∘,¨'sub1' 'sub3' 'sub1/subsub1' 'sub3/subsub3'
  folders←2↑folders
  (⊂⊂matsrc)⎕NPUT¨folders,¨⊂'/mat.apla'
  (⊂⊂tradfn)⎕NPUT¨folders,¨⊂'/tradfn.aplf'
@@ -80,7 +80,7 @@
  (⊂dop2)⎕NPUT(folder,'/sub1/dop.aplo')1
  (⊂NS2'ns')⎕NPUT(folder,'/sub1/ns.apln')1
  3 ⎕NDELETE folder,'/sub3'
- 3 ⎕MKDIR folder,'/sub5/subsub5'
+ 3 QMKDIR folder,'/sub5/subsub5'
  (⊂matsrc2)⎕NPUT(folder,'/sub5/mat.apla')1
  (⊂tradfn2)⎕NPUT(folder,'/sub5/tradfn.aplf')1
  (⊂dop)⎕NPUT(folder,'/sub5/dop.aplo')1


### PR DESCRIPTION
Make Link QA "deterministic" by eliminating race conditions caused by using the FSW during the QA which makes many more or less simultaneous file updates, which can be processed out of sync.

The triggering changes are in "InitGlobals", "SetupSlave" and "LinkCreate"; the rest of the changes are reactions to running the tests and adding calls to new mocked functions.