### PR TITLE
Fix 570

### DIFF
--- a/StartupSession/Link/Config.apln
+++ b/StartupSession/Link/Config.apln
@@ -73,6 +73,8 @@
      
       m←0=≢¨{0::⍬ ⋄ ns⍎⍵,'.⎕NL -2 9'}¨nss←'Debug' 'Settings'
       ns.⎕EX m/nss ⍝ Expunge empty namepaces
+      ⍝ Now remove API/UCMD options which are not save-able settings
+      ns.⎕EX 'Settings.preloaded' 'Settings.ignoreconfig'
      
       json←1 ⎕JSON⍠('Dialect' 'JSON5')('HighRank' 'Split')('Compact' 0)⊢ns
       :If json≢'{',(⎕UCS 13),'}' ⍝ Do not create empty config files
@@ -166,8 +168,11 @@
           'config.Settings'⎕NS dir.Settings
           'config.Debug'⎕NS dir.Debug
      
-          :If ~∧/(names←config.Settings.⎕NL-2)∊valid←(p←LinkParams)[;1]
-              →0⊣(msg config)←('Unknown Setting(s) in "',linkfile,'": ',⍕names~valid)config
+          :If ~∧/(names←config.Settings.⎕NL-2)∊valid←(p←LinkParams)[;1]  
+              ##.U.Warn ('Unknown Setting(s) in "',linkfile,'": ',⍕names~valid) 
+              ⍝ Decided NOT to throw an error for this until further notice
+              ⍝ Possibly reinstate the following line when safe to do so
+              ⍝ →0⊣(msg config)←('Unknown Setting(s) in "',linkfile,'": ',⍕names~valid)config
           :EndIf
      
           :If ~∧/(names←config.Debug.⎕NL-2)∊valid←(p←DebugParams)[;1]

--- a/StartupSession/Link/Create.aplf
+++ b/StartupSession/Link/Create.aplf
@@ -1,10 +1,10 @@
  msg←{opts}Create args;ns;dir;arrow;container;emptydir;emptyns;fail;hasdir;hasns;links;nc;nsref;nsrefs;overwrite;rawns;rsi;warnmsg;xsi;⎕IO;⎕ML;dircreated;DEBUG;setconfig;setopts;z;json;config;rc;isfile;actname;actclass;leaf;ext;file;fulltarget;singlefile;singlenc;nohold;m;nsgiven
  ⎕IO ⎕ML←1 1
  preProcessOpts ⍝ Make sure opts is a namespace
-(container ns dir nsgiven)←preProcessNsDir args
+ (container ns dir nsgiven)←preProcessNsDir args
  (msg setconfig)←dir Config.GetConfig opts
  →(0≠≢msg)⍴0
-:If 2=DEBUG←{6::0 ⋄ ⍵.Debug.debug}setconfig
+ :If 2=DEBUG←{6::0 ⋄ ⍵.Debug.debug}setconfig
      (1+⊃⎕LC)⎕STOP⊃⎕SI
  :EndIf
  :Trap DEBUG↓0
@@ -65,12 +65,12 @@ NOHOLD:
                  emptyns←1
              :Else
                  emptyns←0∊⍴U.ListNames nsref←⍎ns
-                 :If~opts.(preloaded∨flatten)
-                    :If ~emptyns                           ⍝ some APL names defined
-                    :AndIf ~emptydir                       ⍝ some dir/files defined
-                    :AndIf (⊂opts.source)∊'auto' 'dir'     ⍝ will not erase dir
-                     emptyns←emptyns U.EmptyNamespace nsref dir
-                    :EndIf
+                 :If ~opts.(preloaded∨flatten)
+                     :If ~emptyns                           ⍝ some APL names defined
+                     :AndIf ~emptydir                       ⍝ some dir/files defined
+                     :AndIf (⊂opts.source)∊'auto' 'dir'     ⍝ will not erase dir
+                         emptyns←emptyns U.EmptyNamespace nsref dir
+                     :EndIf
                  :EndIf
              :EndIf
          :Else
@@ -132,10 +132,10 @@ NOHOLD:
 
          ⍝ We're all good; do it!
          :If isfile
-              dir←0 U.NormFile fulltarget
+             dir←0 U.NormFile fulltarget
          :Else
-              dir←0 U.NormDir dir
-              ns←U.NormNs ns
+             dir←0 U.NormDir dir
+             ns←U.NormNs ns
          :EndIf
          opts.ns←ns
          opts.dir←dir
@@ -155,7 +155,7 @@ NOHOLD:
          :If ~isfile∨dircreated ⍝ Update source flag cache
              (rc config)←Config.ReadConfigFile dir,'/.linkconfig'
          :AndIf 0=rc
-                 config Config.SetSourceFlags opts
+             config Config.SetSourceFlags opts
          :EndIf
 
          :Select opts.source

--- a/StartupSession/Link/Create.aplf
+++ b/StartupSession/Link/Create.aplf
@@ -57,21 +57,24 @@ NOHOLD:
              emptydir←1 ⋄ isfile←0
          :EndIf
 
-         fulltarget←dir
+         fulltarget←0 U.NormFile dir
          hasns←(|nc)∊singlenc
          :If isfile∨hasns
              :If isfile←nc∊singlenc                 ⍝ Scripted thing
                  dir←¯1↓⊃⎕NPARTS fulltarget         ⍝ Directory is one up
                  emptyns←1
-             :ElseIf ~opts.(preloaded∨flatten)
-                 :If ~emptyns←0∊⍴U.ListNames nsref←⍎ns  ⍝ some APL names defined
-                 :AndIf ~emptydir                       ⍝ some dir/files defined
-                 :AndIf (⊂opts.source)∊'auto' 'dir'     ⍝ will not erase dir
-                 ⍝ link issue #160: allow some APL names to be tied to source files when source is dir - typically happens when starting dyalog with load=boot.aplf - won't work with arrays
-                 emptyns←emptyns U.EmptyNamespace nsref dir
+             :Else
+                 emptyns←0∊⍴U.ListNames nsref←⍎ns
+                 :If~opts.(preloaded∨flatten)
+                    :If ~emptyns                           ⍝ some APL names defined
+                    :AndIf ~emptydir                       ⍝ some dir/files defined
+                    :AndIf (⊂opts.source)∊'auto' 'dir'     ⍝ will not erase dir
+                     emptyns←emptyns U.EmptyNamespace nsref dir
+                    :EndIf
                  :EndIf
              :EndIf
-         :Else ⋄ emptyns←1
+         :Else
+             emptyns←1
          :EndIf
 
          :If opts.singlefile←isfile

--- a/StartupSession/Link/Utils.apln
+++ b/StartupSession/Link/Utils.apln
@@ -588,6 +588,9 @@
       :EndWhile
       :If linked
           linkns←(nss⍳nsref)⊃links
+          :If 0=⎕NC 'linkns.singlefile'  
+              linkns.singlefile←0 ⍝ Protect against fake links created by StartupSession
+          :EndIf
       :EndIf
     ∇
     ∇ links←{links}LookupLinks nsref;linked;links;mask;nss

--- a/StartupSession/Link/Version.aplf
+++ b/StartupSession/Link/Version.aplf
@@ -1,2 +1,2 @@
 version←Version
-version←'4.0.9'
+version←'4.0.10'


### PR DESCRIPTION
Fixes a bug where using "un-normalised" folder names with with Link.Create could throw errors or "mangle" the namespace created from the folder.