### PR TITLE
Fix#571

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,6 @@ nav:
     - Usage/ConfigFiles.md
     - Usage/Setup.md
     - Usage/WStoLink.md
-    - Usage/SALTtoLink.md
     
   - API & Command Reference:
     - API/index.md


### PR DESCRIPTION
Fix #571 - link to old SALT to Link migration guide