### PR TITLE
Create FSW with filters for relevant extensions

### DIFF
--- a/StartupSession/Link/Notify.aplf
+++ b/StartupSession/Link/Notify.aplf
@@ -80,6 +80,13 @@
              :EndIf
          :EndIf
 
+         :If deleted
+            linkedpaths←⊃¨5176⌶0
+            children←((⊃¨⎕NPARTS linkedpaths)∊⊂path,'/')/linkedpaths
+         :AndIf 0<≢children
+            Notify¨{'deleted'⍵}¨children
+         :EndIf
+
          :If dir⍱link U.HasExtn path  ⍝ must be directory or have correct extension
              →END⊣msg,←⊂'file extension not managed by link'
          :ElseIf 0=≢nsref ⋄ warn←1 ⋄ msg,←⊂'unable to find corresponding namespace'

--- a/StartupSession/Link/Notify.aplf
+++ b/StartupSession/Link/Notify.aplf
@@ -163,7 +163,10 @@
                      :Else ⋄ children←0⍴⊂''
                      :EndTrap
                      msg,←'namespace rename 'oldname' → 'affected
-                     Notify¨{'changed'⍵}¨children
+                     children←(link U.HasExtn children)/children
+                     :If 0<≢children
+                         Notify¨{'changed'⍵}¨children
+                     :EndIf
                  :Else
                      :If ~link.flatten
                          warn←1                                    ⍝ no old ns

--- a/StartupSession/Link/Notify.aplf
+++ b/StartupSession/Link/Notify.aplf
@@ -116,6 +116,15 @@
              :ElseIf ~curnc∊0 ¯1    ⍝ file already tied to another name
                  (⍎curnsname)U.Untie curactname
                  msg,←'creating 'affected' - unlinking previously linked 'curname
+             :ElseIf dir
+                 :Trap 0 ⋄ children←⊃⎕NINFO⍠1⊢path,'/*'
+                 :Else ⋄ children←0⍴⊂''
+                 :EndTrap
+                 children←(link U.HasExtn children)/children
+                 :If 0<≢children
+                     Notify¨{'created'⍵}¨children
+                 :EndIf
+                 :If link.flatten ⋄ →END⊣msg,←⊂'ignoring created directory' ⋄ :EndIf
              :Else
                  msg,←'creating 'affected
              :EndIf

--- a/StartupSession/Link/Notify.aplf
+++ b/StartupSession/Link/Notify.aplf
@@ -91,7 +91,7 @@
              →END⊣msg,←⊂'file extension not managed by link'
          :ElseIf 0=≢nsref ⋄ warn←1 ⋄ msg,←⊂'unable to find corresponding namespace'
              →(type≢'deleted')×END ⍝ Exit if event was "deleted", else report error
-         :ElseIf nc=¯1 ⋄ warn←1 ⋄ →END⊣msg,←'invalid name defined by file: 'path
+         :ElseIf (~link.flatten∧dir)∧(nc=¯1) ⋄ warn←1 ⋄ →END⊣msg,←'invalid name defined by file: 'path
          :ElseIf (deleted∨~link.fastLoad)∧(nc=0)  ⍝ cannot trust nc returned by DetermineAplName when opts.fastLoad
              warn←~deleted  ⍝ link issue #235 : the delete callback provoked by ⎕SE.Link.Expunge cannot see the expunged name
              →END⊣msg,←⊂(1+deleted)⊃'invalid file contents' 'could not determine which object was linked to it'
@@ -142,7 +142,7 @@
                  msg,←,'updating previously linked 'affected
              :ElseIf 0≠⎕NC affected  ⍝ redefining existing name
              :AndIf curfile≢oldpath  ⍝ name not bound to old file (TODO won't work for arrays)
-                 warn←1 ⋄ name←'' ⋄ →END⊣msg,←'ignoring attempt to redefine 'affected,(0<≢curfile)/' which is linked to 'curfile
+                 warn←~dir∧link.flatten ⋄ name←'' ⋄ →END⊣msg,←'ignoring attempt to redefine 'affected,(0<≢curfile)/' which is linked to 'curfile
              :EndIf
              :If NOTIFY
                  U.Notify oldpath,' renamed as ',path
@@ -164,8 +164,11 @@
                      :EndTrap
                      msg,←'namespace rename 'oldname' → 'affected
                      Notify¨{'changed'⍵}¨children
-                 :Else ⋄ warn←1                                    ⍝ no old ns
-                     msg,←'namespace 'oldname' not found. Loading 'affected' from 'path
+                 :Else
+                     :If ~link.flatten
+                         warn←1                                    ⍝ no old ns
+                         msg,←'namespace 'oldname' not found. Loading 'affected' from 'path
+                     :EndIf
                      :If 0<≢inFail←2⊃link U.FixFiles nsref path 1  ⍝ always overwrite
                          msg,←' - failed to load: '(U.FmtLines inFail)
                      :EndIf

--- a/StartupSession/Link/Utils.apln
+++ b/StartupSession/Link/Utils.apln
@@ -700,9 +700,9 @@
           ⍝ Link             0|1     (default 1)   ⍝ maintain the link to the file - link issue #155
               FIX←where.⎕FIX⍠('Quiet' 1)('AllowLateBinding' 1)('FixWithErrors'force)('Link'(~0∊⍴file))
           :EndIf
-      ⍝:If (⌊|where.⎕NC⊂name)∊3 4 ⋄ (stops trace monitor)←(where.⎕STOP name)(where.⎕TRACE name)(⊣/where.⎕MONITOR name)  ⍝ link issue #148 and #129
-      ⍝:Else ⋄ stops←trace←monitor←⍬
-      ⍝:EndIf
+          :If (⌊|where.⎕NC⊂name)∊3 4 ⋄ (stops trace monitor)←(where.⎕STOP name)(where.⎕TRACE name)(⊣/where.⎕MONITOR name)  ⍝ link issue #148 and #129
+          :Else ⋄ stops←trace←monitor←⍬
+          :EndIf
       ⍝ attempt to fix as named script because this is the most commly expected format
           :Trap 0 ⋄ names←(2 FIX src)  ⍝ fn/op/script - can work from file
           :Else ⋄ names←0⍴⊂''
@@ -711,9 +711,9 @@
               :If 1=≢names ⋄ name←⊃names ⋄ nc←where.⎕NC⊂name
               :Else ⋄ name←'' ⋄ nc←0  ⍝ multiple names in single file not supported
               :EndIf
-          ⍝:If ((⌊|nc)∊3 4)∧(0∨.<⊃∘⍴¨stops trace monitor)  ⍝ restore stops, traces and monitor - monitor timing information will be lost
-          ⍝    stops where.⎕STOP name ⋄ trace where.⎕TRACE name ⋄ monitor where.⎕MONITOR name
-          ⍝:EndIf
+              :If ((⌊|nc)∊3 4)∧(0∨.<⊃∘⍴¨stops trace monitor)  ⍝ restore stops, traces and monitor - monitor timing information will be lost
+                  stops where.⎕STOP name ⋄ trace where.⎕TRACE name ⋄ monitor where.⎕MONITOR name
+              :EndIf
               :Return  ⍝ named script fixed
           :EndIf
       ⍝required←11 116≡⎕DMX.(EN ENX)  ⍝ 2 ⎕FIX failed because cannot read :Required file

--- a/StartupSession/Link/Watcher.apln
+++ b/StartupSession/Link/Watcher.apln
@@ -109,31 +109,48 @@
       :EndDisposable
     ∇
 
-    ∇ watcher←MakeWatcher args;⎕USING
-     ⍝ Return a FileSystemWatcher object
+    ∇ r←MakeWatcher args;filter;filters;path;watcher;⎕USING
+     ⍝ Return FileSystemWatcher object(s)
      ⍝ Try .Net Core rather than Framework if non-Windows or DYALOG_NETCORE explicitly set
+     ⍝ Creates a vector of watchers on .Net Framework to watch specific extensions.
+     ⍝ dotnet supports collection of filters on single watcher.
       ⎕USING←',System',(~DOTNETCORE)/'.dll'
-      watcher←⎕NEW System.IO.FileSystemWatcher
-      watcher.(Path Filter)←args
-      watcher.(onChanged onCreated onDeleted onRenamed)←⊂'WatchEvent'
-      watcher.onError←'WatchError'
-      watcher.IncludeSubdirectories←1
+      path filters←args
+      :If DOTNETCORE
+          watcher←⎕NEW System.IO.FileSystemWatcher
+          watcher.Path←path
+          watcher.Filters.Add¨⊂¨⊆filters
+          watcher.(onChanged onCreated onDeleted onRenamed)←⊂'WatchEvent'
+          watcher.onError←'WatchError'
+          watcher.IncludeSubdirectories←1
+          r←watcher
+       :Else
+          r←⍬
+          :For filter :In ⊆filters
+             watcher←⎕NEW System.IO.FileSystemWatcher
+             watcher.Path←path
+             watcher.Filter←filter
+             watcher.(onChanged onCreated onDeleted onRenamed)←⊂'WatchEvent'
+             watcher.onError←'WatchError'
+             watcher.IncludeSubdirectories←1
+             r,←watcher
+          :EndFor
+       :EndIf
     ∇
-
 
 
 
    ⍝⍝⍝⍝⍝ MAIN API ⍝⍝⍝⍝⍝⍝⍝⍝
 
-    ∇ Watch link;args;end;q;r;tid;z
+    ∇ Watch link;filters;end;q;r;tid;z
     ⍝ Set up a file system watcher, return object that will be stored as "fsw" in ⎕SE.Link.Links[i]
       link.fsw←⎕NULL
       :If ~'dir' 'both'∊⍨⊂link.watch
           :Return
       :EndIf
       :If DOTNET
-          args←link.dir(,'*')
-          r←MakeWatcher args
+          filters←(⊂'*.'),¨∪link.(codeExtensions,customExtensions,⊢/typeExtensions)
+          r←MakeWatcher link.dir filters
           r.EnableRaisingEvents←1
           link.fsw←r
       :ElseIf CRAWLER

--- a/StartupSession/Link/Watcher.apln
+++ b/StartupSession/Link/Watcher.apln
@@ -110,7 +110,7 @@
     ∇
 
     ∇ r←MakeWatcher args;filter;filters;path;watcher;⎕USING
-     ⍝ Return FileSystemWatcher object(s)
+     ⍝ Return FileSystemWatcher objects
      ⍝ Try .Net Core rather than Framework if non-Windows or DYALOG_NETCORE explicitly set
      ⍝ Creates a vector of watchers on .Net Framework to watch specific extensions.
      ⍝ dotnet supports collection of filters on single watcher.
@@ -150,7 +150,7 @@
           :Return
       :EndIf
       :If DOTNET
-          filters←(⊂'*.'),¨∪link.(codeExtensions,customExtensions,⊢/typeExtensions)
+          filters←(⊂'*.'),¨∪link.(codeExtensions,customExtensions)
           r←MakeWatcher link.dir filters
           r.EnableRaisingEvents←1
           link.fsw←r

--- a/StartupSession/Link/Watcher.apln
+++ b/StartupSession/Link/Watcher.apln
@@ -5,7 +5,7 @@
     DYALOGVERSION←1 .1+.×2↑⊃(//)'.'⎕VFI 2⊃'.'⎕WG'AplVersion'  ⍝ required at ⎕FIX time - can't rely on ##.U
     IS180←18≤DYALOGVERSION
     IS181←18.1≤DYALOGVERSION
-
+    BUFFER←⍬                                ⍝ event buffer for throttling FSW events
     CRAWLER←0                               ⍝ allow using crawler
 
 
@@ -72,14 +72,27 @@
     ∇ WatchEvent(obj args);ct;nargs;timers
      ⍝ Callback for System.IO.FileSystemWatcher instance
      ⍝ Passes info on to ⎕SE.Link.Notify for processing
-      {}2501⌶0 ⍝ Reap the thread on exit - triggers mantis 17628
+      ⍝{}2501⌶0 ⍝ Reap the thread on exit - triggers mantis 17628
       ⍝{}2502⌶0  ⍝ Discard parked thread - workaround mantis 17628
       nargs←⊂0 ##.U.CaseText⍕args.ChangeType
       nargs,←⊂args.FullPath
       :If 0≠⎕NC⊂'args.OldFullPath'
           nargs,←⊂args.OldFullPath
       :EndIf
-      obj ##.Notify&nargs
+      BUFFER,←⊂obj nargs
+      THROTTLE.FireOnce←1
+    ∇
+
+    ∇ WatchEventThrottle args;evts;types;targets
+     ⍝ Throttle calls to Notify and filter/re-order events
+      {}2502⌶0 ⍝ Discard parked thread
+      BUFFER←(≢evts←BUFFER)↓BUFFER
+      types←(⊂2 1)⊃¨evts
+      evts←evts[⍋'deleted' 'created' 'renamed' 'changed'⍳types]
+      targets←(⊂2 2)⊃¨evts
+      evts←evts[∪⍳⍨targets]
+      {##.Notify/↑⍵}&evts
+     ⍝
     ∇
 
     ∇ WatchError(obj args);link;msg
@@ -110,7 +123,7 @@
     ∇
 
     ∇ r←MakeWatcher args;filter;filters;path;watcher;⎕USING
-     ⍝ Return FileSystemWatcher objects
+     ⍝ Return vector of FileSystemWatcher objects
      ⍝ Try .Net Core rather than Framework if non-Windows or DYALOG_NETCORE explicitly set
      ⍝ Creates a vector of watchers on .Net Framework to watch specific extensions.
      ⍝ dotnet supports collection of filters on single watcher.
@@ -137,6 +150,13 @@
       r.(onChanged onCreated onDeleted onRenamed)←⊂⊂'WatchEvent'
       r.onError←⊂'WatchError'
       r.IncludeSubdirectories←1
+      r.InternalBufferSize←65536 ⍝ Max size is 64KB
+      :If 0=⎕NC'THROTTLE'
+          THROTTLE←⎕NEW⊂'Timer'
+          THROTTLE.FireOnce←2
+          THROTTLE.Interval←200
+          THROTTLE.onTimer←'WatchEventThrottle'
+      :EndIf
     ∇
 
 

--- a/StartupSession/Link/Watcher.apln
+++ b/StartupSession/Link/Watcher.apln
@@ -116,26 +116,27 @@
      ⍝ dotnet supports collection of filters on single watcher.
       ⎕USING←',System',(~DOTNETCORE)/'.dll'
       path filters←args
+      watcher←⎕NEW System.IO.FileSystemWatcher
+      watcher.Filter←,'*'
+      watcher.NotifyFilter←System.IO.NotifyFilters.DirectoryName
+      r←,watcher
       :If DOTNETCORE
           watcher←⎕NEW System.IO.FileSystemWatcher
-          watcher.Path←path
           watcher.Filters.Add¨⊂¨⊆filters
-          watcher.(onChanged onCreated onDeleted onRenamed)←⊂'WatchEvent'
-          watcher.onError←'WatchError'
-          watcher.IncludeSubdirectories←1
-          r←watcher
-       :Else
-          r←⍬
+          watcher.NotifyFilter←System.IO.NotifyFilters.(FileName+LastWrite)
+          r,←watcher
+      :Else
           :For filter :In ⊆filters
-             watcher←⎕NEW System.IO.FileSystemWatcher
-             watcher.Path←path
-             watcher.Filter←filter
-             watcher.(onChanged onCreated onDeleted onRenamed)←⊂'WatchEvent'
-             watcher.onError←'WatchError'
-             watcher.IncludeSubdirectories←1
-             r,←watcher
+              watcher←⎕NEW System.IO.FileSystemWatcher
+              watcher.Filter←filter
+              watcher.NotifyFilter←System.IO.NotifyFilters.(FileName+LastWrite)
+              r,←watcher
           :EndFor
-       :EndIf
+      :EndIf
+      r.Path←⊂path
+      r.(onChanged onCreated onDeleted onRenamed)←⊂⊂'WatchEvent'
+      r.onError←⊂'WatchError'
+      r.IncludeSubdirectories←1
     ∇
 
 


### PR DESCRIPTION
This is a bit of a hack as it creates a vector of watchers when running on .Net Framework and that may not be what the rest of the Link code expects.

I've gone through the code to check the impact and see a reference ot a QUEUE object that might cause issues, but can't see what is creating it. Apart from that the other places where `link.fsw` is referenced it should work ok both when fsw is a vector and a scalar object.