### PR TITLE
Fix #601

### DIFF
--- a/StartupSession/Link/Config.apln
+++ b/StartupSession/Link/Config.apln
@@ -194,7 +194,9 @@
      
           :Trap 0
               config←0 ⎕JSON⍠('Hierarchy' 0)('Dialect' 'JSON5')⊢json←⊃⎕NGET file 0
-              ⍝⍝ /// reconstitute matrix settings
+              :If 2=⎕NC 'config.Settings.typeExtensions'
+                  config.Settings.(typeExtensions←↑typeExtensions)
+              :EndIf
           :Else
               →0⊣(rc config)←1('Invalid configuration file: "',file,'": ',⎕DMX.Message)
           :EndTrap

--- a/Test/test_config.aplf
+++ b/Test/test_config.aplf
@@ -1,4 +1,4 @@
- ok←test_config(folder name);z;config;userfile;ns;files;export;getj5;fn;link;here
+ ok←test_config(folder name);z;config;userfile;ns;files;export;getj5;fn;link;here;opts
 ⍝ Verify that the system is using configuration according to the spex
 
 getj5←{⎕JSON⍠'Dialect' 'JSON5'⊢⊃⎕NGET ⍵}
@@ -128,5 +128,18 @@ getj5←{⎕JSON⍠'Dialect' 'JSON5'⊢⊃⎕NGET ⍵}
  z←⎕SE.Link.Import name export
  assert '''foo'' ''goo''≡',name,'.⎕NL -3' ⍝ Should be 2 functions in there after flattening
  3 ⎕NDELETE export
+
+⍝ --- Test non-default typeExtensions (fix for #601)
+ 3 ⎕NDELETE folder
+ opts.typeExtensions←3 2⍴2 'zzza' 3 'zzzf' 4 'zzzo' 9.1⊣opts←⎕NS ''
+ z←opts LinkCreate name folder
+ z←⎕SE.Link.Break name
+ z←LinkCreate name folder
+ link←GetLink name
+ assert '(getj5 folder,''/.linkconfig'').Settings.typeExtensions≡↓opts.typeExtensions'
+ assert 'opts.typeExtensions≡3 2↑link.typeExtensions'
+ z←⎕SE.Link.Break name
+ ⎕EX name
+
  CleanUp folder name
  ok←1


### PR DESCRIPTION
The typeExtensions option is a 2-column matrix. JSON cannot represent it. I had already left a comment in the code that we would need to "reconstitute matrix settings".

It did surprise me that we don't just use the typeExtensions matrix provided by the user, but make sure that there are always settings for types 2 3 4 9.1 9.4 and 9.5 and add the defaults if necessary. I was about to log an issue about this, but after thinking about it a wee bit longer, I decided that it made good sense.

I have added a comment about this to the documentation of typeExtensions on the Link.Create page.