### PR TITLE
fix missing file extension for link.configure in arrays.md

### DIFF
--- a/docs/Usage/Arrays.md
+++ b/docs/Usage/Arrays.md
@@ -2,7 +2,7 @@
 
 By default, Link uses *APL Array Notation (APLAN)* to store arrays in text files. While APLAN is a good format for describing numeric data, nested arrays and many high rank arrays, it is not ideal for storing text data. Link 4.0 introduces experimental support for storing multi-line character data in simple text files.
 
-The configuration setting `text` can be used to enable this feature: If `text` is set to `'aplan'` (the default) then all arrays will be store using APLAN. If `text` is set to `'plain'` (the default) then text arrays that adhere to a set of very specific criteria will instead be stored in plain text files. You can set this option when a link is created, or using [`Link.Configure`](../API/Link.Configure).
+The configuration setting `text` can be used to enable this feature: If `text` is set to `'aplan'` (the default) then all arrays will be store using APLAN. If `text` is set to `'plain'` (the default) then text arrays that adhere to a set of very specific criteria will instead be stored in plain text files. You can set this option when a link is created, or using [`Link.Configure`](../API/Link.Configure.md).
 
 Text files which are not in APLAN format will have a penultimate "sub-extension" section in the file name which records the format of the original array in the workspace. The below table describes the array file extensions, what the content represents, and the specific criteria for storage in plain text file.
 


### PR DESCRIPTION
- Possible fix for #648 

I have added the missing file extension for the URL for `link.configure.md`

Earlier the link gave a 404 error when redirected to the GitHub md file. I am not sure how this fits for mkdocs.