### PR TITLE
Make IO independent AT call, fix #643

### DIFF
--- a/StartupSession/Link/Fix.aplf
+++ b/StartupSession/Link/Fix.aplf
@@ -161,7 +161,7 @@ NOHOLD:
                      3 ⎕MKDIR file
                  :Else  ⍝ file
                      3 ⎕MKDIR 1⊃⎕NPARTS file ⍝ make sure folder is there
-                     src(nsref U.Into)name nsref.{3 4∊⍨⎕NC ⍺:⍵(2⊃⎕AT ⍺) ⋄ ⍵}file
+                     src(nsref U.Into)name nsref.{3 4∊⍨⎕NC ⍺:⍵(2 ⎕AT ⍺) ⋄ ⍵}file
                      :If NOTIFY∧callback∧link.watch≡'ns'
                          ⍝ If watching files, notification happens on FSW event
                          U.Notify nsname,'.',name,' written to ',file


### PR DESCRIPTION
Fixes issue when using Link for namespace that has IO = 0.