### PR TITLE
Fix #554 Allow link of non-empty ns to folder which only contains "irrelevant" files

### DIFF
--- a/StartupSession/Link/Create.aplf
+++ b/StartupSession/Link/Create.aplf
@@ -1,4 +1,4 @@
- msg←{opts}Create args;ns;dir;arrow;container;emptydir;emptyns;fail;hasdir;hasns;links;nc;nsref;nsrefs;overwrite;rawns;rsi;warnmsg;xsi;⎕IO;⎕ML;dircreated;DEBUG;setconfig;setopts;z;json;config;rc;isfile;actname;actclass;leaf;file;fulltarget;singlefile;singlenc;nohold;m;nsgiven;up;parts;ext
+ msg←{opts}Create args;ns;dir;arrow;container;emptydir;emptyns;fail;hasdir;hasns;links;nc;nsref;nsrefs;overwrite;rawns;rsi;warnmsg;xsi;⎕IO;⎕ML;dircreated;DEBUG;setconfig;setopts;z;json;config;rc;isfile;actname;actclass;leaf;file;fulltarget;singlefile;singlenc;nohold;m;nsgiven;up;parts;ext;name;type
  ⎕IO ⎕ML←1 1
  preProcessOpts ⍝ Make sure opts is a namespace
  (container ns dir nsgiven)←preProcessNsDir args
@@ -51,7 +51,8 @@ NOHOLD:
                  nsref←container
                  emptydir←0
              :Else
-                 emptydir←0∊⍴⊃(⎕NINFO⍠1)dir,'/*'
+                 (name type)←0 1 (⎕NINFO⍠('Wildcard' 1)('Recurse' 2))dir,'/*'
+                 emptydir←0=≢(opts.codeExtensions,⊂'apla')∩1↓¨3⊃¨⎕NPARTS¨(type=2)/name
              :EndIf
          :Else
              emptydir←1 ⋄ isfile←0

--- a/Test/test_create.aplf
+++ b/Test/test_create.aplf
@@ -137,6 +137,11 @@
  z←opts LinkCreate name folder
  'link issue #230'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
  {}⎕SE.Link.Break name
+ (⊂'Hello') ⎕NPUT folder,'/hello.txt'
+ z←opts LinkCreate name folder
+ 'link issue #554'assert'~∨/''ERRORS ENCOUNTERED''⍷z'
+ {}⎕SE.Link.Break name
+ ⎕NDELETE folder,'/hello.txt'
  subname⍎'foo←{⍺+⍵}'
  assertError'opts LinkCreate name folder' 'Cannot link a non-empty namespace to a non-empty directory'
  ⎕EX subname,'.foo'


### PR DESCRIPTION
Interpret target directory as "empty" if it doesn't contain any files with relevant extensions