### PR TITLE
Fix #421: provide better information when source files cannot be read

### DIFF
--- a/StartupSession/Link/Create.aplf
+++ b/StartupSession/Link/Create.aplf
@@ -53,7 +53,7 @@ NOHOLD:
                  emptydir←0
              :Else
                  (name type)←0 1 (⎕NINFO⍠('Wildcard' 1)('Recurse' 2))dir,'/*'
-                 emptydir←0=≢(opts.codeExtensions,⊂'apla')∩1↓¨3⊃¨⎕NPARTS¨(type=2)/name
+                 emptydir←~∨/(1↓¨3⊃¨⎕NPARTS(type=2)/name)∊opts.codeExtensions,⊂'apla' ⍝ Any code here?
              :EndIf
          :Else
              emptydir←1 ⋄ isfile←0

--- a/StartupSession/Link/Utils.apln
+++ b/StartupSession/Link/Utils.apln
@@ -789,6 +789,8 @@
           :If 1=type←1 ⎕NINFO file ⋄ src←⎕NULL  ⍝ directory → namespace
           :ElseIf 2=type ⋄ src←GetFile file     ⍝ file
           :EndIf
+      :Else
+          Warn 'Unable to read "',file,'": ',⎕DMX.Message
       :EndTrap
     ∇
 


### PR DESCRIPTION
The fix consists of adding an :Else clause to a :Trap and displaying ⎕DMX.Message. 
With this in place, you will see warnings like the following:

      ⎕SE.Link.Create # 'c:\tmp\linktest-421'
Link Warning: Unable to read "c:/tmp/linktest-421/f.aplf": Unicode character ⎕UCS 9051 (U+235B) not in ⎕AVU
Linked: # ←→ "c:\tmp\linktest-421"
ERRORS ENCOUNTERED:
1 import(s) failed:
"c:\tmp\linktest-421\f.aplf"