### PR TITLE
Fix issues 536 & 537, and fix issues testing HandleEventQueue

### DIFF
--- a/StartupSession/Link/Expunge.aplf
+++ b/StartupSession/Link/Expunge.aplf
@@ -34,7 +34,7 @@
                          :If link.singlefile
                              U.Error'You may not Expunge an object within a linked namespace, class or interface'
                          :EndIf
-                         (file oldfile)←2↑link(0 U.DetermineFileName)(⍕parent)leaf leaf nc  ⍝ U.NormNs parent
+                         (file oldfile)←2↑link(0 U.DetermineFileName)(⍕parent)leaf leaf nc ⍬ ⍝ U.NormNs parent
                          :If (parent.⎕NC leaf)∊3 4
                              z←Stop name ⍬
                              z←Trace name ⍬

--- a/StartupSession/Link/Fix.aplf
+++ b/StartupSession/Link/Fix.aplf
@@ -59,7 +59,7 @@ NOHOLD:
          :AndIf (⍕where)≢⊃U.SplitNs link.ns ⍝ Target space is parent of link.ns
              U.Error'May not Fix inside a linked namespace, class or interface'
          :EndIf
-         (file oldfile nc)←link(0 U.DetermineFileName)nsname name oldname src
+         (file oldfile nc)←link(0 U.DetermineFileName)nsname name oldname src ⍬
 
          :If nc=¯1 ⋄ U.Error'Invalid name: ',nsname,'.',name
          :ElseIf (0=nc)∧(~nosrc) ⋄ U.Error'Invalid source for ',nsname,'.',name ⍝ ,': ',⍕src

--- a/StartupSession/Link/GetFileName.aplf
+++ b/StartupSession/Link/GetFileName.aplf
@@ -15,7 +15,7 @@
              (parent name)←U.SplitNs name
              :If ~nc∊0 ¯1
              :AndIf ~0∊⍴link←links U.LookupRef parent←⍎parent
-                 (file oldfile nc)←link(0 U.DetermineFileName)(⍕parent)name name ⍬  ⍝ U.NormNs parent
+                 (file oldfile nc)←link(0 U.DetermineFileName)(⍕parent)name name ⍬ ⍬ ⍝ U.NormNs parent
                  (i⊃files)←(~nc∊0 ¯1)/(1+0<≢oldfile)⊃file oldfile
              :Else
                  (i⊃files)←''

--- a/StartupSession/Link/Notify.aplf
+++ b/StartupSession/Link/Notify.aplf
@@ -104,7 +104,7 @@
          :EndIf
 
          ⍝ determine current file tied to name we plan to use
-         expfile←⊃link(0 U.DetermineFileName)nsname actname oldname nc
+         expfile←⊃link(0 U.DetermineFileName)nsname actname oldname nc path
          :If 0∊⍴curfile←0 U.NormFile nsref U.CurrentFileName actname ⍝ not tied by interpreter
          :AndIf 2.1 ¯9.1∊⍨nc   ⍝ only arrays and tradnamespaces don't have ties
              curfile←U.Deslash(⎕NEXISTS expfile)/expfile ⍝ ns source may be folder with trailing /

--- a/StartupSession/Link/Utils.apln
+++ b/StartupSession/Link/Utils.apln
@@ -1061,7 +1061,7 @@
       file←ApplyOldExtn⍣(~forceExtensions)⊢file  ⍝ doesn't sound like a good idea - the existing .dyalog file could define something different (in particular if one of the two files is an array and casecode is off)
       ⍝ Allow user to determine file name - they return '' to give up
       :If 3=(⍎ns).⎕NC getFilename
-      :AndIf 0<≢userfile←(ns⍎getFilename)'getFilename'opts file(ns,'.',name)(|nc)(ns,'.',oldname)
+      :AndIf 0<≢userfile←(ns⍎getFilename)'getFilename'opts file(where,'.',name)(|nc)(ns,'.',oldname)
           file←userfile
       :EndIf
     ∇

--- a/StartupSession/Link/Utils.apln
+++ b/StartupSession/Link/Utils.apln
@@ -975,7 +975,7 @@
           :EndTrap ⋄ :EndIf
     ∇
 
-    ∇ (file oldfile nc)←opts(depth DetermineFileName)(where name oldname src);args;cache
+    ∇ (file oldfile nc)←opts(depth DetermineFileName)(where name oldname src curfile);args;cache
     ⍝ opts cached for performance on ns lookup
      
       :If 0=⎕NC'opts.ignorecurrent' ⋄ opts.ignorecurrent←0 ⋄ :EndIf
@@ -995,16 +995,16 @@
       cache←opts,opts.(dir ns flatten caseCode typeExtensions forceFilenames forceExtensions beforeWrite getFilename fastLoad)
      
       :If depth
-          :If 0∊⍴args←↓⍉↑(where name oldname src)
+          :If 0∊⍴args←↓⍉↑(where name oldname src curfile)
               (file oldfile nc)←⊂0⍴⊂''
           :Else
               (file oldfile nc)←↓⍉↑cache∘DetermineFileNameSub¨args
           :EndIf
       :Else
-          (file oldfile nc)←cache DetermineFileNameSub(where name oldname src)
+          (file oldfile nc)←cache DetermineFileNameSub(where name oldname src curfile)
       :EndIf
     ∇
-    ∇ (file oldfile nc)←opts DetermineFileNameSub(where name oldname src);⎕AVU;beforeWrite;caseCode;dir;ext;fastLoad;flatten;forceExtensions;forceFilenames;getFilename;isroot;nc;ns;oldfile;path;ref;subdir;typeExtensions;userfile;subext
+    ∇ (file oldfile nc)←opts DetermineFileNameSub(where name oldname src curfile);⎕AVU;beforeWrite;caseCode;dir;ext;fastLoad;flatten;forceExtensions;forceFilenames;getFilename;isroot;nc;ns;oldfile;path;ref;subdir;typeExtensions;userfile;subext
     ⍝ what should the file name be according to link
     ⍝ src may be the (nested) text source of item, or may be the scalar name class
     ⍝ where must have been through NormNs
@@ -1060,6 +1060,9 @@
       file←subdir,file,subext,ext
       file←ApplyOldExtn⍣(~forceExtensions)⊢file  ⍝ doesn't sound like a good idea - the existing .dyalog file could define something different (in particular if one of the two files is an array and casecode is off)
       ⍝ Allow user to determine file name - they return '' to give up
+      :If opts.flatten∧0≠≢curfile ⍝ Notify passes file name down
+          file←curfile
+      :EndIf
       :If 3=(⍎ns).⎕NC getFilename
       :AndIf 0<≢userfile←(ns⍎getFilename)'getFilename'opts file(where,'.',name)(|nc)(ns,'.',oldname)
           file←userfile
@@ -1215,7 +1218,7 @@
           :If file
               files←,⊂dest ⋄ oldfiles←,⊂''  ⍝ file name explicitly provided
           :Else
-              (files oldfiles)←2↑opts(1 DetermineFileName)(count/⊂ns)names names(count/⊂'')  ⍝ names are known to exist so don't provide source
+              (files oldfiles)←2↑opts(1 DetermineFileName)(count/⊂ns)names names(count/⊂'') ⍬ ⍝ names are known to exist so don't provide source
               :If opts.(singlefile∧caseCode)
                   opts.dir←⊃files ⍝ replace with case coded name
               :EndIf
@@ -1343,7 +1346,7 @@
      
       ⍝ rename files if incorrectly named - cannot work with opts.fastLoad
       :If (0<≢allfiles)∧opts.(fastLoad<forceExtensions∨forceFilenames)
-          expfiles←⊃opts(1 DetermineFileName)parents actnames actnames actncs
+          expfiles←⊃opts(1 DetermineFileName)parents actnames actnames actncs ⍬
           expfiles←expfiles(opts.forceFilenames MergeFileName opts.forceExtensions)¨allfiles
           :If ∨/mask←expfiles≢¨allfiles
               :If (≢expfiles)≠(≢∪0 CaseText expfiles)
@@ -1502,7 +1505,7 @@
       expname←((0<≢¨where)∧(0<≢¨expname))/¨where JoinNames expname  ⍝ fully qualified name
       (mask/expname)←(mask←where≡¨actname)/where  ⍝ roots have where≡expname≡actname
       subname←(1+≢link.ns)↓¨name
-      expfile←⊃link(1 DetermineFileName)((≢name)⍴⊂link.ns)subname subname namenc
+      expfile←⊃link(1 DetermineFileName)((≢name)⍴⊂link.ns)subname subname namenc ⍬
       ⍝ expfile←(⎕NEXISTS expfile)/¨expfile  ⍝ not necesary since file shouldn't be listed anyways
       (filemask namemask)←0<(nameifile fileiname)←name file{(0<≢¨⍵)×(0@((1+≢⍺)∘=)⍺⍳⍵)}¨expname expfile  ⍝ 0 for not found
       filemask∧←filemask\(⍸filemask)=fileiname[filemask/nameifile]  ⍝ link must be both ways

--- a/StartupSession/Link/Version.aplf
+++ b/StartupSession/Link/Version.aplf
@@ -1,2 +1,2 @@
  version←Version
- version←'4.1.1'
+ version←'4.1.2'

--- a/StartupSession/Link/Watcher.apln
+++ b/StartupSession/Link/Watcher.apln
@@ -491,7 +491,7 @@
           ⍝    delmask∧←delmask\mask\0=#.⎕NC mask/delmask/oldnames    ⍝ variables in directory may not appear in ListLinkedNs - delete only if name class is zero
           ⍝:EndIf
           :If 1∊delmask ⋄ :AndIf watchns
-              delfiles←⊃link(1 ##.U.DetermineFileName)((+/delmask)⍴⊂ns)((1+≢ns)↓¨delmask/oldnames)((+/delmask)⍴⊂'')(delmask/items[I_NC;])
+              delfiles←⊃link(1 ##.U.DetermineFileName)((+/delmask)⍴⊂ns)((1+≢ns)↓¨delmask/oldnames)((+/delmask)⍴⊂'')(delmask/items[I_NC;]) ⍬
               allfiles←4⊃¨5177⌶⍬
               :If 1∊mask←delfiles∊allfiles  ⍝oldfiles∩allfiles  ⍝ some oldfiles still tied - should not happen
                   (mask/delmask/oldnames){1 LogCrawler'Deleted APL item: file still in use: '⍺' → '⍵}¨(mask/delfiles)
@@ -510,7 +510,7 @@
                   (newnames newnc newsrc)/⍨←⊂~mask
               :EndIf
           :AndIf ~0∊⍴newnames
-              newfiles←⊃link(1 ##.U.DetermineFileName)((≢newnames)⍴⊂ns)((1+≢ns)↓¨newnames)((≢newnames)⍴⊂'')newnc
+              newfiles←⊃link(1 ##.U.DetermineFileName)((≢newnames)⍴⊂ns)((1+≢ns)↓¨newnames)((≢newnames)⍴⊂'')newnc ⍬
               newnames{0 LogCrawler'Created APL item: '⍺' → '⍵}¨newfiles
               newsrc ##.U.Into¨newfiles ⋄ newhash←##.U.FileHash¨newfiles ⋄ newmod←EncodeTS↑3 ⎕NINFO newfiles
               delmask∨←(items[I_FILE;]∊newfiles)  ⍝ remove previous entries on those files - newfiles can never be ''

--- a/StartupSession/Link/Watcher.apln
+++ b/StartupSession/Link/Watcher.apln
@@ -261,8 +261,10 @@
     ⍝ Called by ⎕SE.Link.Break
       :If CRAWLER ⋄ RemoveCrawler links ⋄ :EndIf  ⍝ can't hurt on empty links or non-crawled links
       :If ~0∊⍴links
-      :AndIf ~0∊⍴links←(⎕NULL≢¨links.fsw)/links  ⍝ links that have a FSW
-          links.fsw.EnableRaisingEvents←0
+      :AndIf ~0∊⍴links←(~⎕NULL∊¨links.fsw)/links  ⍝ links that have a FSW   
+          :Trap 90
+              links.fsw.EnableRaisingEvents←0 ⍝ Ignore if this fails - as it will after a )CLEAR    
+          :EndTrap
           (⍕¨links.ns)DisposeFSW&¨links.fsw
           links.fsw←⎕NULL
       :EndIf

--- a/Test/onBasicWrite.aplf
+++ b/Test/onBasicWrite.aplf
@@ -1,5 +1,5 @@
  r←onBasicWrite args;event;extn;file;link;name;nc;oldname;src;value
- (event link file name nc oldname src)←7↑args
+ (event link file name nc oldname src)←ONBASICWRITEARGS←7↑args
  r←1 ⍝ Link should carry on; we're not handling this one
  :If 2=⌊nc ⍝ A variable
      :Select ⎕DR value←⍎name

--- a/Test/onFlatFilename.aplf
+++ b/Test/onFlatFilename.aplf
@@ -1,6 +1,6 @@
  r←onFlatFilename args;event;ext;file;link;name;nc;oldname
     ⍝ Callback functions to implement determining target folder for flattened link
- (event link file name nc oldname)←6↑args
+ (event link file name nc oldname)←ONFLATFILENAMEARGS←6↑args
  :If 0≠≢r←4⊃5179⌶oldname     ⍝ we could find info for oldname
      :If name≢oldname ⍝ copy / rename of an existing function
          name←(⌽∧\⌽name≠'.')/name  ⍝ drop namespace specification

--- a/Test/test_basic.aplf
+++ b/Test/test_basic.aplf
@@ -75,6 +75,7 @@
       ⍝ Put a copy of foo in the folder
  _←(⊂foo)QNPUT folder,'/sub/foo.dyalog'
  assert'foo≡ns.sub.⎕NR ''foo'''
+ assert '''#.linktest.sub.onetwo''≡4⊃ONBASICWRITEARGS' ⍝ Verify fix to #537
 
       ⍝ Create a class with missing dependency
  _←(⊂ac←':Class aClass : bClass' ':EndClass')QNPUT folder,'/sub/aClass.dyalog'

--- a/Test/test_flattened.aplf
+++ b/Test/test_flattened.aplf
@@ -26,8 +26,14 @@
  assert'dupfile≡4⊃5179⌶''ns.dup'''             ⍝   ... await callback & link established
 
  goofile←folder,'/app/goo.aplf'
+ goo←' r←goo x' ' r←x x x'
+ (⊂goo) QNPUT goofile                           ⍝ Create a new function by writing to file
+ assert '''/app/goo.aplf''≡¯13↑3⊃ONFLATFILENAMEARGS' ⍝ Test fix for #536
 
- ns'goo'⎕SE.Link.Fix↑goo←' r←goo x' ' r←x x x'  ⍝ Add a new function, this time using a matrix
+ QNDELETE goofile                               ⍝ Get rid of it again
+ assert'0=ns.⎕NC ''goo'''
+
+ ns'goo'⎕SE.Link.Fix↑goo    ⍝ Recreate the new function, this time using a matrix
  assert'goo≡⊃⎕NGET goofile 1'
  assert'goofile≡4⊃5179⌶''ns.goo'''             ⍝   ... await callback & link established
 


### PR DESCRIPTION
Most of the changes have to do with issue 536, where Notify needed to pass the notified file name down to DetermineFileNameSub so that it can be passed to the user callback.