### PR TITLE
Do not rely on editor for source when ALWAYSREFORMAT is set

### DIFF
--- a/StartupSession/Link/Fix.aplf
+++ b/StartupSession/Link/Fix.aplf
@@ -105,7 +105,7 @@ NOHOLD:
              :If oldname≢⊃ns U.Fix oldname(ns.⎕NR oldname)1  ⍝ repair damage done by editor - 0 ⎕ATX may hold an incorrect version, compared to ⎕NR
                  U.Error'Could not fix ',(⍕ns),'.',oldname
              :EndIf
-         :ElseIf callback∧(0=≢oldfile)∧(oldname≡name)  ⍝ new name - link issue #196 v18.0 needs to preserve source as typed
+         :ElseIf (ALWAYSREFORMAT=0)∧callback∧(0=≢oldfile)∧(oldname≡name)  ⍝ new name - link issue #196 v18.0 needs to preserve source as typed
              :If (1↓U.LASTFIX)≢(⍕ns)(oldname) ⋄ U.Error'Fixing error: last fix is ',(⍕2⊃U.LASTFIX),'.',(3⊃U.LASTFIX),' instead of ',(⍕ns),'.',(oldname) ⋄ :EndIf
              :If 2=ns.⎕NC name ⋄ src←ns U.GetAplSource name link ⍝ source of array
              ⍝:ElseIf ~tie ⋄ :AndIf (ns.⎕NC name)∊3 4 ⍝ functions not tied to file cannot preserve whitespace - Link.Diff would otherwise report a diff between file and namespace

--- a/StartupSession/Link/Version.aplf
+++ b/StartupSession/Link/Version.aplf
@@ -1,2 +1,2 @@
  version←Version
- version←'4.1.5'
+ version←'4.1.6'


### PR DESCRIPTION
Fix #731 by not using the LASTFIX cache when ALWAYSREFORMAT is set, but instead calling GetAplSource which returns source according to ALWAYSREFORMAT settings.

Testing this requires a v19.0 or v20.0 interpreter built after 2025-06-27, because part of the problem was that Link.OnAfterFix was not being called for new functions when AUTOFORMATSCRIPTS=1, because from the interpreter's perspective a new function is not "a script" yet - Link has not written it to file.