### PR TITLE
Recordflags

### DIFF
--- a/StartupSession/Link/Config.apln
+++ b/StartupSession/Link/Config.apln
@@ -18,6 +18,7 @@
     LinkParams⍪←'typeExtensions' ''
     LinkParams⍪←'fastLoad' 0
     LinkParams⍪←'text' 'aplan'
+    LinkParams⍪←'recordFlags' 0
 
     DebugParams←'notify' 'debug',⍪0 0
 
@@ -69,6 +70,7 @@
      
       :If 2=⎕NC'ns.SourceFlags'
       :AndIf 0=≢ns.SourceFlags
+      :AndIf islink
           ns.⎕EX'SourceFlags' ⍝ No flags
       :EndIf
      
@@ -76,6 +78,10 @@
       ns.⎕EX m/nss ⍝ Expunge empty namepaces
       ⍝ Now remove Version and API/UCMD options which are not save-able settings
       ns.⎕EX'LinkVersion'
+      :If 0=⎕NC'ns.Settings.recordFlags'
+      :OrIf ~ns.Settings.recordFlags
+          ns.⎕EX'SourceFlags'
+      :EndIf
       :If 9=⎕NC'ns.Settings' ⍝ Expunge all Settings which are not LinkParams
           ns.Settings.⎕EX(ns.Settings.⎕NL-2)~LinkParams[;1]
       :EndIf
@@ -89,6 +95,8 @@
       :EndIf
      
       :If islink
+      :AndIf 0≠⎕NC'ns.Settings.recordFlags'
+      :AndIf ns.Settings.recordFlags
           ns SetSourceFlags linkorfile
       :EndIf
     ∇

--- a/StartupSession/Link/Create.aplf
+++ b/StartupSession/Link/Create.aplf
@@ -90,7 +90,7 @@ NOHOLD:
          :EndIf
 
          :If opts.singlefile←isfile
-             z←'forceFilenames' 'forceExtensions' 'flatten' ⍝ Not allowed
+             z←'forceFilenames' 'forceExtensions' 'flatten' 'recordFlags' ⍝ Not allowed
          :AndIf ∨/m←opts⍎⍕z
              U.Error'Not allowed in single-file links: ',⍕m/z
          :EndIf

--- a/StartupSession/Link/Status.aplf
+++ b/StartupSession/Link/Status.aplf
@@ -34,7 +34,7 @@
          opts←defopts U.DefaultOpts opts
          :If ~opts.extended∊0 1 ⋄ U.Error'Invalid value ',(⍕opts.extended),' for modifier "extended" - must be one of: 0 1' ⋄ :EndIf
 
-         props←('Case' 'Code')'Flatten'('Force' 'Extensions')('Force' 'Filenames')'Watch'
+         props←('Case' 'Code')'Flatten'('Force' 'Extensions')('Force' 'Filenames')'Watch'('Record' 'Flags')
          :If (opts.extended)
              :If ×≢links
                  :For prop :In props

--- a/StartupSession/Link/Utils.apln
+++ b/StartupSession/Link/Utils.apln
@@ -638,7 +638,7 @@
       :If ''≡0⍴opts ⋄ opts←⎕SE.Dyalog.Array.Deserialise opts ⍝ pseudo array notation (experimental)
       :Else ⋄ opts←⎕SE.Link.⎕NS opts  ⍝ duplicate namespace to avoid changing caller's, and to avoid having cross-refs between # and ⎕SE
       :EndIf
-      modifiers←'source' 'watch' 'flatten' 'caseCode' 'forceExtensions' 'forceFilenames' 'arrays' 'sysVars' 'fastLoad' 'beforeWrite' 'beforeRead' 'getFilename' 'customExtensions' 'codeExtensions' 'typeExtensions' 'proceed' 'preloaded' 'ignoreconfig' 'text'
+      modifiers←'source' 'watch' 'flatten' 'caseCode' 'forceExtensions' 'forceFilenames' 'arrays' 'sysVars' 'fastLoad' 'beforeWrite' 'beforeRead' 'getFilename' 'customExtensions' 'codeExtensions' 'typeExtensions' 'proceed' 'preloaded' 'ignoreconfig' 'text' 'recordFlags'
       :If ~900⌶⍬ ⋄ modifiers,←defopts.⎕NL ¯2 ⋄ :EndIf
       :If ∨/mask←~(nl←opts.⎕NL ¯2)∊modifiers
           Error'Unknown modifiers: ',FmtEach mask/nl
@@ -651,8 +651,8 @@
       'source'Default'auto' ⋄ 'source'Check'auto' 'dir' 'ns'
       'watch'Default'both' ⋄ 'watch'Check'both' 'dir' 'ns' 'none'
       'text'Default'aplan' ⋄ 'text'Check'aplan' 'plain'
-      'flatten' 'caseCode' 'forceExtensions' 'forceFilenames' 'fastLoad' 'sysVars' 'preloaded' 'ignoreconfig'Default 0
-      'flatten' 'caseCode' 'forceExtensions' 'forceFilenames' 'fastLoad' 'sysVars' 'preloaded' 'ignoreconfig'Check¨⊂0 1
+      'flatten' 'caseCode' 'forceExtensions' 'forceFilenames' 'fastLoad' 'sysVars' 'preloaded' 'ignoreconfig' 'recordFlags'Default 0
+      'flatten' 'caseCode' 'forceExtensions' 'forceFilenames' 'fastLoad' 'sysVars' 'preloaded' 'ignoreconfig' 'recordFlags'Check¨⊂0 1
       Check←Error{''≢0⍴v←⍵⍵⍎⍵:⍺⍺'Modifier "',⍵,'" must be a text vector' ⋄ (~0∊⍴v)∧(3≠⎕NC v):Error'Modifier ',⍵,' must be the name of an APL function' ⋄ 1:_←1}opts
       'beforeWrite' 'beforeRead' 'getFilename'Default'' ⋄ Check¨'beforeWrite' 'beforeRead' 'getFilename'
       Check←Error{∨/{''≢0⍴⍵}¨⊆⍵⍵⍎⍵:⍺⍺'Modifier "',⍵,'" must be a text vector or vector of text vectors' ⋄ 1:_←1}opts
@@ -1995,9 +1995,9 @@
       r,←'{"Name":"Add",         "args":"items[←def]",       "Parse":"", "Desc":"Associate items in linked namespaces with new files/directories in corresponding directory, optionally with simultaneous definition"},'
       r,←'{"Name":"Break",       "args":"[ns1]",             "Parse":"9999S -all[=]# ⎕SE * -recursive=on off error",  "Desc":"Break link between namespace and corresponding directory"},'
       ⍝r,←'{"Name":"CaseCode",    "args":"file1",             "Parse":"1L", "Desc":"Append filename with numeric encoding of capitalisation"},'
-      r,←'{"Name":"Create",      "args":"[ns] dir",          "Parse":"1-2L -source=ns dir auto -watch=none ns dir both -casecode -forceextensions -forcefilenames -arrays[=] -sysvars -flatten -beforeread= -beforewrite= -getfilename= -codeextensions= -typeextensions= -fastload -ignoreconfig -text=aplan plain","Desc":"Link a namespace with a directory (create one but not both if non-existent)"},'
+      r,←'{"Name":"Create",      "args":"[ns] dir",          "Parse":"1-2L -source=ns dir auto -watch=none ns dir both -casecode -forceextensions -forcefilenames -arrays[=] -sysvars -flatten -beforeread= -beforewrite= -getfilename= -codeextensions= -typeextensions= -fastload -ignoreconfig -text=aplan plain -recordflags","Desc":"Link a namespace with a directory (create one but not both if non-existent)"},'
       r,←'{"Name":"Configure",   "args":"target [settings]", "Parse":"1-9999 -create", "Desc":"Set directory or user configuration options"},'
-      r,←'{"Name":"Export",      "args":"ns0 dir2",          "Parse":"1-2L -overwrite -arrays[=] -sysvars -casecode -ignoreconfig -text=aplan plain", "Desc":"Export a namespace to a directory (create the directory if absent); does not create a link"},'
+      r,←'{"Name":"Export",      "args":"ns0 dir2",          "Parse":"1-2L -overwrite -arrays[=] -sysvars -casecode -ignoreconfig -text=aplan plain -recordflags", "Desc":"Export a namespace to a directory (create the directory if absent); does not create a link"},'
       r,←'{"Name":"Expunge",     "args":"[item]",            "Parse":"9999S",  "Desc":"Erase item and associated file"},'
       r,←'{"Name":"GetFileName", "args":"item",              "Parse":"1",  "Desc":"Return name of file associated with item"},'
       r,←'{"Name":"GetItemName", "args":"file",              "Parse":"1L", "Desc":"Return name of item associated with file"},'
@@ -2040,6 +2040,7 @@
       m⍪←'-sysvars' '' 'Export namespace-scoped system variables to file for all unscripted namespaces'
       m⍪←'-typeextensions' '=<var>' 'name of two-column matrix with name classes and extensions'
       m⍪←'-watch' '={none|ns|dir|both}' 'which source to track for changes so the other can be synchronised'
+      m⍪←'-recordflags' '' 'save stop and trace flags to configuration file'
       (mods modVals modTxts)←↓⍉m
       myMods←'-\pL+'⎕S'&'⊢info.Parse
       myModI←⊂mods⍳myMods
@@ -2098,7 +2099,7 @@
       :Case 2  ⍝ ambivalent or dyadic
           'opts'⎕NS ⍬
           :If 9=40 ⎕ATX'args' ⍝ args has been parsed
-              names←'all' 'arrays' 'beforeRead' 'beforeWrite' 'caseCode' 'codeExtensions' 'extended' 'fastLoad' 'flatten' 'forceExtensions' 'forceFilenames' 'getFilename' 'overwrite' 'proceed' 'recursive' 'source' 'sysVars' 'typeExtensions' 'watch' 'create' 'ignoreconfig' 'text'
+              names←'all' 'arrays' 'beforeRead' 'beforeWrite' 'caseCode' 'codeExtensions' 'extended' 'fastLoad' 'flatten' 'forceExtensions' 'forceFilenames' 'getFilename' 'overwrite' 'proceed' 'recursive' 'source' 'sysVars' 'typeExtensions' 'watch' 'create' 'ignoreconfig' 'text' 'recordFlags'
               :For name :In names
                   lc←0 CaseText name
                   :If ×args.⎕NC lc

--- a/StartupSession/Link/Version.aplf
+++ b/StartupSession/Link/Version.aplf
@@ -1,2 +1,2 @@
  version←Version
- version←'4.1.7'
+ version←'4.2.0'

--- a/Test/test_config.aplf
+++ b/Test/test_config.aplf
@@ -2,16 +2,34 @@
 ⍝ Verify that the system is using configuration according to the spex
 
  getj5←{⎕JSON⍠'Dialect' 'JSON5'⊢⊃⎕NGET ⍵}
+
+ SetConfig'' ⍝ Clear user config file
+ 3 ⎕NDELETE Retry⊢folder
+ 3 ⎕MKDIR Retry⊢folder
+ ⎕EX name
+ z←LinkCreate name folder
+ ns←⍎name
+ ns.⎕FX'foo' '2+2'
+ ns.⎕FX'bar' '3+3'
+ 1 ns.⎕STOP'foo'   ⍝ Check that Link.Add will NOT register existing stops
+ z←⎕SE.Link.Add name∘,¨'.foo' '.bar'
+ files←2⊃¨⎕NPARTS⊃⎕NINFO⍠1⊢folder,'/*'
+ ⎕SE.Link.Stop'bar' 1  ⍝ Check that Link.Stop will NOT register new stops
+ assert'''foo'' ''bar'' ≡⍥{⍵[⍋⍵]} files'
+ link←GetLink name
+ assert'0=≢link.flagged'
+
 ⍝ --- Link.Configure set user config ---
  SetConfig'' ⍝ Clear user config file
- z←⎕SE.Link.Configure'*' 'watch:ns' 'caseCode:1' ⍝ Set options
+ z←⎕SE.Link.Configure'*' 'watch:ns' 'caseCode:1' 'recordFlags:1' ⍝ Set options
  assert'∧/1∊¨''watch: '' ''caseCode: ''⍷¨⊂z'
  config←getj5 ⎕SE.Link.USERCONFIGFILE
- assert'(''caseCode'' ''watch'')≡config.Settings.⎕NL -2'
+ assert'(''caseCode'' ''recordFlags'' ''watch'')≡config.Settings.⎕NL -2'
  assert'⎕SE.Link.Version≡config.LinkVersion.ID'
 
 ⍝ --- Link.Create ---
 ⍝ Test that Link.Create uses the user config
+ 3 ⎕NDELETE Retry⊢folder
  3 ⎕MKDIR Retry⊢folder
  ⎕EX name
 
@@ -39,7 +57,7 @@
  assert'(,⊂''foo'')≡link.flagged'
  assert'(,1)≡link.flags[1].Stop'
  config←getj5 folder,'/.linkconfig'
- assert'(''caseCode'' ''watch'')≡config.Settings.⎕NL -2'
+ assert'(''caseCode'' ''recordFlags'' ''watch'')≡config.Settings.⎕NL -2'
  assert'''ns'' 1≡config.Settings.(watch caseCode)' ⍝ Check that settings ended up in the directory config
  assert'1≡≢config.SourceFlags'
  assert'(,1)≡config.SourceFlags[1].Stop'
@@ -78,8 +96,8 @@
 
 ⍝ Test that folder config is used if user config says nothing
 
- z←⎕SE.Link.Configure'*' 'watch:' 'caseCode:' ⍝ Clear user config settings
- assert'∧/1∊¨''watch:ns'' ''caseCode:1''⍷¨⊂z'
+ z←⎕SE.Link.Configure'*' 'watch:' 'caseCode:' 'recordFlags:' ⍝ Clear user config settings
+ assert'∧/1∊¨''watch:ns'' ''caseCode:1'' ''recordFlags:1''⍷¨⊂z'
  assert'0=⎕NEXISTS ⎕SE.Link.USERCONFIGFILE' ⍝ No settings
 
  z←LinkCreate name folder
@@ -131,13 +149,13 @@
 
 ⍝ --- Test non-default typeExtensions (fix for #601)
  3 ⎕NDELETE folder
- opts.typeExtensions←3 2⍴2 'zzza' 3 'zzzf' 4 'zzzo' 9.1⊣opts←⎕NS ''
+ opts.typeExtensions←3 2⍴2 'zzza' 3 'zzzf' 4 'zzzo' 9.1⊣opts←⎕NS''
  z←opts LinkCreate name folder
  z←⎕SE.Link.Break name
  z←LinkCreate name folder
  link←GetLink name
- assert '(getj5 folder,''/.linkconfig'').Settings.typeExtensions≡↓opts.typeExtensions'
- assert 'opts.typeExtensions≡3 2↑link.typeExtensions'
+ assert'(getj5 folder,''/.linkconfig'').Settings.typeExtensions≡↓opts.typeExtensions'
+ assert'opts.typeExtensions≡3 2↑link.typeExtensions'
  z←⎕SE.Link.Break name
  ⎕EX name
 

--- a/docs/API/Link.Create.md
+++ b/docs/API/Link.Create.md
@@ -1,7 +1,7 @@
 # Link.Create
 
 ## Syntax
-    ]LINK.Create [ns] <dirorfile> [-source={ns|dir|auto}] [-watch={none|ns|dir|both}] [-casecode] [-forceextensions] [-forcefilenames] [-arrays] [-sysvars] [-flatten] [-preloaded] [-beforeread=<fn>] [-beforewrite=<fn>] [-getfilename=<fn>] [-codeextensions=<var>] [-typeextensions=<var>] [-fastload] [-ignoreconfig] [-text={aplan|plain}]
+    ]LINK.Create [ns] <dirorfile> [-source={ns|dir|auto}] [-watch={none|ns|dir|both}] [-casecode] [-forceextensions] [-forcefilenames] [-arrays] [-sysvars] [-flatten] [-preloaded] [-beforeread=<fn>] [-beforewrite=<fn>] [-getfilename=<fn>] [-codeextensions=<var>] [-typeextensions=<var>] [-fastload] [-ignoreconfig] [-text={aplan|plain}] [-recordflags]
     
     message ← {options} ⎕SE.Link.Create (namespace directory)
 
@@ -94,6 +94,7 @@ Default: **off**
 
 The **ignoreconfig** allows you to ignore the `.linkconfig` file in the linked directory. This can be useful during debugging, especially if you have a damaged configuration file.
 
+See [Configuration Files](../Usage/ConfigFiles.md#the-ignoreconfig-switch) for details.
 
 ### **flatten**
 Default: **off**
@@ -280,12 +281,12 @@ Side effects are (again, only at initial load time, not at subsequent events):
 
 This option takes effect only when **source** is **dir**.
 
-### **ignoreconfig**
+### **recordFlags**
 Default: **off**
 
-Ignores any Link configuration files.
+Saves `⎕STOP` and `⎕TRACE` values as part of the configuration file.
 
-See [Configuration Files](../Usage/ConfigFiles.md#the-ignoreconfig-switch) for details.
+See [Configuration Files](../Usage/ConfigFiles.md#stop-and-trace-flags) for details.
 
 ### **text**
 Default: **aplan**

--- a/docs/API/Link.Export.md
+++ b/docs/API/Link.Export.md
@@ -1,6 +1,6 @@
 # Link.Export
 
-    ]LINK.Export [ns] <dir> [-overwrite] [-casecode] [-arrays{=name1,name2,...}] [-sysvars] [-ignoreconfig] [-text={aplan|plain}]
+    ]LINK.Export [ns] <dir> [-overwrite] [-casecode] [-arrays{=name1,name2,...}] [-sysvars] [-ignoreconfig] [-text={aplan|plain}] [-recordflags]
     
     msg ← {opts} ⎕SE.Link.Export (ns dir) 
 

--- a/docs/Usage/ConfigFiles.md
+++ b/docs/Usage/ConfigFiles.md
@@ -47,9 +47,11 @@ The result documents that there was no previous setting for the option. A file c
 ```
 ### Stop and Trace flags
 
-Directory configuration files also record stop and trace settings for functions and operators in the linked directory, which you can either manipulate in the editor, or using the API functions [Link.Stop](../API/Link.Stop.md) and [Link.Trace](../API/Link.Trace.md):
+Directory configuration files can record stop and trace settings for functions and operators in the linked directory. This is enabled with [the `recordConfig` setting](../API/Link.Create.md#recordFlags). You can either manipulate the settings in the editor, or using the API functions [Link.Stop](../API/Link.Stop.md) and [Link.Trace](../API/Link.Trace.md):
 
 ```
+      ]link.create linkdemo c:\tmp\linkdemo -recordflags
+      …
       ]link.stop linkdemo.stats.Mean 2
 Was linkdemo.stats.Mean 1
 ```


### PR DESCRIPTION
From now on, Link will by default NOT record `⎕STOP` and `⎕TRACE`.

Note that version number 4.1.7 → 4.2.0, but while this just removes what is generally considered an annoyance, it _is_ actually a breaking change. Do we want to go all the way to 5.0.0?