### PR TITLE
fix: correct namespace plural typo in workspace warning

### DIFF
--- a/StartupSession/Link/WSLoaded.aplf
+++ b/StartupSession/Link/WSLoaded.aplf
@@ -70,7 +70,7 @@
              U.Warn(⊂msg),(⍕¨wslinks.ns)
          :EndIf
      :ElseIf 0≠≢wslinks
-         msg←(⍕≢wslinks),' namespaces',('s '/⍨1≠≢wslinks),' linked in this workspace: '
+         msg←(⍕≢wslinks),' namespace',('s '/⍨1≠≢wslinks),'linked in this workspace: '
          'IMPORTANT'U.Warn(⊂msg),⍕¨wslinks.ns
          'IMPORTANT'U.Warn'Link.Resync is required'
      :Else


### PR DESCRIPTION
Fix doubled-"s" typo in the workspace load warning message.

Before: `2 namespacess linked in this workspace`
After: `2 namespaces linked in this workspace`

The base string "namespaces" had a hardcoded trailing "s", and the plural marker added another "s", producing "namespacess". Changed to "namespace" so the plural marker works correctly: "1 namespace" / "2 namespaces".

Fixes #766