### PR TITLE
docs: fix recordConfig → recordFlags in ConfigFiles.md

### DIFF
--- a/StartupSession/Link/WSLoaded.aplf
+++ b/StartupSession/Link/WSLoaded.aplf
@@ -70,7 +70,7 @@
              U.Warn(⊂msg),(⍕¨wslinks.ns)
          :EndIf
      :ElseIf 0≠≢wslinks
-         msg←(⍕≢wslinks),' namespaces',('s '/⍨1≠≢wslinks),' linked in this workspace: '
+         msg←(⍕≢wslinks),' namespace',('s '/⍨1≠≢wslinks),'linked in this workspace: '
          'IMPORTANT'U.Warn(⊂msg),⍕¨wslinks.ns
          'IMPORTANT'U.Warn'Link.Resync is required'
      :Else

--- a/docs/Usage/ConfigFiles.md
+++ b/docs/Usage/ConfigFiles.md
@@ -47,7 +47,7 @@ The result documents that there was no previous setting for the option. A file c
 ```
 ### Stop and Trace flags
 
-Directory configuration files can record stop and trace settings for functions and operators in the linked directory. This is enabled with [the `recordConfig` setting](../API/Link.Create.md#recordFlags). You can either manipulate the settings in the editor, or using the API functions [Link.Stop](../API/Link.Stop.md) and [Link.Trace](../API/Link.Trace.md):
+Directory configuration files can record stop and trace settings for functions and operators in the linked directory. This is enabled with [the `recordFlags` setting](../API/Link.Create.md#recordFlags). You can either manipulate the settings in the editor, or using the API functions [Link.Stop](../API/Link.Stop.md) and [Link.Trace](../API/Link.Trace.md):
 
 ```
       ]link.create linkdemo c:\tmp\linkdemo -recordflags


### PR DESCRIPTION
The ConfigFiles documentation incorrectly referenced `recordConfig` — the correct setting name is `recordFlags`.

Fixes #763